### PR TITLE
Create command to convert base64 to image

### DIFF
--- a/mech_client/cli.py
+++ b/mech_client/cli.py
@@ -4,6 +4,7 @@ from mech_client import __version__
 from mech_client.interact import interact as interact_
 from mech_client.prompt_to_ipfs import main as prompt_to_ipfs_main
 from mech_client.push_to_ipfs import main as push_to_ipfs_main
+from mech_client.to_png import main as to_png_main
 
 
 @click.group(name="mechx")  # type: ignore
@@ -35,9 +36,19 @@ def push_to_ipfs(file_path: str) -> None:
     push_to_ipfs_main(file_path=file_path)
 
 
+@click.command()
+@click.argument("ipfs_hash")
+@click.argument("path")
+@click.argument("request_id")
+def to_png(ipfs_hash: str, path: str, request_id: str) -> None:
+    """Convert a stability AI API's diffusion model output into a PNG format."""
+    to_png_main(ipfs_hash, path, request_id)
+
+
 cli.add_command(interact)
 cli.add_command(prompt_to_ipfs)
 cli.add_command(push_to_ipfs)
+cli.add_command(to_png)
 
 
 if __name__ == "__main__":

--- a/mech_client/to_png.py
+++ b/mech_client/to_png.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""
+This script facilitates the conversion of a stability AI API's diffusion model output into a PNG format.
+
+Usage:
+
+python push_to_ipfs.py <ipfs_hash> <path>
+"""
+import json
+import os.path
+from base64 import b64decode
+from tempfile import gettempdir
+
+from aea_cli_ipfs.ipfs_utils import IPFSTool
+
+
+def to_png(data: dict, path: str) -> None:
+    """Stores a stability AI API's diffusion model output into a PNG formatted file."""
+    for i, image in enumerate(data["artifacts"]):
+        with open(path, "wb") as f:
+            f.write(b64decode(image["base64"]))
+
+    print(f"Successfully created {path}.")
+
+
+def get_from_ipfs(ipfs_hash: str, request_id: str) -> dict:
+    """Get data from IPFS."""
+    temp_dir = gettempdir()
+    IPFSTool().client.get(cid=ipfs_hash, target=temp_dir)
+    stored_data = os.path.join(temp_dir, ipfs_hash)
+
+    with open(os.path.join(stored_data, request_id)) as f:
+        data = json.loads(f.read()).get("result", {})
+
+    if not isinstance(data, dict):
+        raise ValueError("Data do not have the expected format!")
+
+    return data
+
+
+def main(ipfs_hash: str, path: str, request_id: str) -> None:
+    data_ = get_from_ipfs(ipfs_hash, request_id)
+    to_png(data_, path)


### PR DESCRIPTION
Adds a command to convert a stability AI API's diffusion model output into a PNG format.

Current limitations:

1. Hash can only be in the `bafybei` format.
2. `path` can only be filename at the moment. Specifying a path with folders will not work.
3. Potential exceptions not handled, e.g., if the given hash does not contain the expected data