### PR TITLE
chore: bump open-autonomy and open-aea

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {},
     "third_party": {
-        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeidwcobzb7ut3efegoedad7jfckvt2n6prcmd4g7xnkm6hp6aafrva",
-        "protocol/valory/acn/1.1.0": "bafybeignmc5uh3vgpuckljcj2tgg7hdqyytkm6m5b6v6mxtazdcvubibva",
+        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeihdnfdth3qgltefgrem7xyi4b3ejzaz67xglm2hbma2rfvpl2annq",
+        "protocol/valory/acn/1.1.0": "bafybeiapa5ilsobggnspoqhspftwolrx52udrwmaxdxgrk26heuvl4oooa",
         "protocol/valory/acn_data_share/0.1.0": "bafybeieyixetwvz767zekhvg7r6etumyanzys6xbalx2brrfswybinnlhi"
     }
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -268,114 +268,114 @@ develop = ["coverage (>=5.3)", "flake8 (>=3.8)", "isort (>=5.8)", "mypy (>=0.900
 
 [[package]]
 name = "bitarray"
-version = "2.7.6"
+version = "2.8.0"
 description = "efficient arrays of booleans -- C extension"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "bitarray-2.7.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:82816e361303817ac79d6870d51a3c7f1f343e816a0b1d885b713389d9bba425"},
-    {file = "bitarray-2.7.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b798d37fcd8e78e381660a65c434c3f60713c6f076fcecfd22544ec46d7416e6"},
-    {file = "bitarray-2.7.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f5b133a161bb4426e0bdd0e53be979dfdc5f63f14043b8e194d1fba6391e1672"},
-    {file = "bitarray-2.7.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aafd10decf8940e8f2d21e25b32b21ae9fd1aa58f168ea97f0f82adb0f6aa33a"},
-    {file = "bitarray-2.7.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:913e767a3d9a50d2213f5e22db4e87b8a29acc38be5001d29b6be42b1361b812"},
-    {file = "bitarray-2.7.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ffcde9d694bfb34f82e6739b33fd267bad25e6b4042b43bfffbe3ba31184318"},
-    {file = "bitarray-2.7.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31be9ffbb6dd777233331b2fc08d30957cb01f86e2ee11aa5d7652158fa3b795"},
-    {file = "bitarray-2.7.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:190d7e018565f0745c76ced5060c2a0a218efb5b3e5df71f8a0da5661decaaf7"},
-    {file = "bitarray-2.7.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab8fc4de49c75ef358fa9a30a367a163f62b92048a3da084500b88283aba47a6"},
-    {file = "bitarray-2.7.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1211d16de1814f910fc7f2de74930ea22b4feb9b699eed5ceaef8ed14736fe50"},
-    {file = "bitarray-2.7.6-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:0f8e85acce0c3434776fc82819dfd09d9003595456f838d50b1009d6ac0be031"},
-    {file = "bitarray-2.7.6-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:e095f92ba7c6424fc4918f28ddc998e1628bbf83bd5b0405c08c5591f74560a3"},
-    {file = "bitarray-2.7.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:98959be5e864bed9c4fcd90d47d96cf5250d86a2a22b39ec41514c54c80f29bd"},
-    {file = "bitarray-2.7.6-cp310-cp310-win32.whl", hash = "sha256:c6a13db2090c16a8753a6b6fb0e5ac0c7ece1930d4fa85c20e885aec550bceb3"},
-    {file = "bitarray-2.7.6-cp310-cp310-win_amd64.whl", hash = "sha256:31b2855bd566c965ec00ca5629a2637786e0605005826be0f6f192f3756f2aa2"},
-    {file = "bitarray-2.7.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:87fd489d5b82679528fe096084c4e6976199874edc3c126bb41cd668987bd784"},
-    {file = "bitarray-2.7.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:557cc0858e5171b542ed48bbb58ae83bc65da82fb3fd88dafd21e33ba1b685d3"},
-    {file = "bitarray-2.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7e40be8a46062ff89c07fe00a0ea7e06a069805cf1f9cb57196a89f52fdcaf80"},
-    {file = "bitarray-2.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98e1abda299b516573aa916e4c58bb870dd55f17dd544041d9290cb1c005be30"},
-    {file = "bitarray-2.7.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6897bfadf3077685c73cd6ca60ebeaaa40b3bbe060f38f0a6c577bebe37935f4"},
-    {file = "bitarray-2.7.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30a9347acb24a0ee50cc932c52f58337d5b9503bb5b78f435cf3a47cd7031d86"},
-    {file = "bitarray-2.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f16a5e4fd0614d43c1bd5bd0887deca1fcf292253662bce040c169492005fd8a"},
-    {file = "bitarray-2.7.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:02a871ee6f460d03febdd1577ddab66c7f297a43eff3293ee4cb34f6eb5cacb6"},
-    {file = "bitarray-2.7.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e373bd92a6caf9bb6bb2918e3f6e64ba10045d62c2e376d80d0ec062dcdb19ef"},
-    {file = "bitarray-2.7.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ca4dc98b56461d3656f3219cfcc4a6845479ab7e6cdc134c7fa2615336c55f76"},
-    {file = "bitarray-2.7.6-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:2b3527f41bbfd4b8b64b9d7541cd9f8234b0d5a477e59b8c7f666f6f9635ea09"},
-    {file = "bitarray-2.7.6-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4d77b8ed242fa4b70a609e0bf81dd1f2db161ff4a082f7dfe233b491fe4c0c39"},
-    {file = "bitarray-2.7.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:efe64997aeabedbaf24543020cc5c672d00cb373e126c12fe7e21e128f548001"},
-    {file = "bitarray-2.7.6-cp311-cp311-win32.whl", hash = "sha256:5ac235eb59737bffce44d605a2c1af47e56e28a98bc7c9c763587e8bd8c5ebe0"},
-    {file = "bitarray-2.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:2c2bbb73b8dbc52dd26ae40ae83f2e863fc48db6c37ea7fbfd5a750ec62c0a30"},
-    {file = "bitarray-2.7.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d15685830b607088f040ec512d045ab762678d33e813e882a260ae3ee3d381db"},
-    {file = "bitarray-2.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94333a9f419ddf2f92ddbdb34a10a4b2c13e346f077511a35de87a0acea4289f"},
-    {file = "bitarray-2.7.6-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cff6588ec89b276bab617b15778b20aeb5124df1e04b1c0b5364e9cb8dce6a7f"},
-    {file = "bitarray-2.7.6-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:60acdb34def45f72f50a2277763b2a979e4c42dcb4c183a3a9a75bfe195e0b65"},
-    {file = "bitarray-2.7.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88bfe996b1adb811690333523e2500d700f6d3dfb282b0b77194e8ff1d168873"},
-    {file = "bitarray-2.7.6-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a56e6e68d0a508b0a2bd81840e31c41f4858585cd72f192264c4f0f8f48fd0c1"},
-    {file = "bitarray-2.7.6-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e1ec302eda30e87793bd31c16c18a92118a1072831200247d0a8430e095e9563"},
-    {file = "bitarray-2.7.6-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:4d054a65a9b3848744e49f195ef7399841c545c05ad11854982e271331a4577c"},
-    {file = "bitarray-2.7.6-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:26e4f99f5bdb20c9275dcb5bde44aaae74c52224f328bf1f691be43d6eaccc2b"},
-    {file = "bitarray-2.7.6-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:523de6f222c310a865f4070f79b2ad0e0b35b9f26b34ee9f93a3dc8ad293dbfb"},
-    {file = "bitarray-2.7.6-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bcc8bd9fe25b48cff1702a6ef700f7a7726c8084be8edcae67a1df0d23caa822"},
-    {file = "bitarray-2.7.6-cp36-cp36m-win32.whl", hash = "sha256:0efcd03263f70f76298e56b6c5ed454ba89c01777ac25a790725bc063c6170b9"},
-    {file = "bitarray-2.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:31c118dcaaad605c3d8ef953c79554f4822e454e85649dd9fe82e3fcd5017eef"},
-    {file = "bitarray-2.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:216c113c68523b0d3a0f98c5d12236a1998b5c3bf79bfa17324368bf9d20cd26"},
-    {file = "bitarray-2.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4451de47a3b2b378f03bc12d4cf49e64895dc263befee2af38420a91e38d4f9"},
-    {file = "bitarray-2.7.6-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ad4c0e7e20c7384a111ce1883b91e203fc7950a6d4bb3ccdad23422b359ab4a"},
-    {file = "bitarray-2.7.6-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f57e3e6362d2ca7ab797e423a2d5ed1934b8599d197097458c714cf107f4dc4a"},
-    {file = "bitarray-2.7.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f21b59a436ec2f8226c397292e24f9dfb9c3eba904038f50778f2365e68fdea"},
-    {file = "bitarray-2.7.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae83573d9f30f085755c7ba519f0498ecb773a0f2a7e428ed2a33324975e1cec"},
-    {file = "bitarray-2.7.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5f36666371fcf8c1adaa0184b5762a7ce8310fdd33f5c39bf085c6dfe5fb0699"},
-    {file = "bitarray-2.7.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5df77a37750fff8a107fba2e7adb887d171ae923306fa9a6c6c6c1a22c73da7f"},
-    {file = "bitarray-2.7.6-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:08abec79d033ee10d6f4cb2fa9aec952d18eb06ce034b9cdf0cd8e6f2d023254"},
-    {file = "bitarray-2.7.6-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:790aa2272aa6a2b792404a9f672dd136801a3a3860f74298c2542f63a206ed49"},
-    {file = "bitarray-2.7.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:95749278b59247a2a5779f1a0fc216f110eea1aa8af330609b8bdb5f8f55b78f"},
-    {file = "bitarray-2.7.6-cp37-cp37m-win32.whl", hash = "sha256:5ebb24415e5838a729484ae698e1a17e27b826d2691d5cc6d4dc44a90f6a89e6"},
-    {file = "bitarray-2.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:79da57026eb2c6b266c55d578b607f71d2eb9c5ae1bb3b32232d7dae059d63ed"},
-    {file = "bitarray-2.7.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3e9065cbc14ac490e4b1b5520ef33d61e9bdb41d066c7f18b20429c3025ea07e"},
-    {file = "bitarray-2.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e6f228712a5696f3e13048894fc1f6d70d32421e154476b74595b0309a9d9dcf"},
-    {file = "bitarray-2.7.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5b803225158bbe17384e0a9f15cffecb5ae019b4d225a21887670ef20acfa4c8"},
-    {file = "bitarray-2.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7cc2fd90298cb5e4c5882a8d8f4b39db23280a94387ba10ca266c311135ca57a"},
-    {file = "bitarray-2.7.6-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:72f638b6e56480c588580d10e3185dc9770d66a2bee49735ae6ac4277eb701da"},
-    {file = "bitarray-2.7.6-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1802d92ba8b97a758f61f6aef8324c7705fe35a4b32ce9ed1569a8ddb43f0e33"},
-    {file = "bitarray-2.7.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2cdcd0b5f6952ed7187f46a7f0ea72436ddbd7111af2263adcbfe2850d0c26e7"},
-    {file = "bitarray-2.7.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db83ad25c3ea908f1c983b4b28ab5b9408a18962fa21724a5d1d65887842462d"},
-    {file = "bitarray-2.7.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:98afc87b14868bb51f478f01c4d1578a190efb60c1b44dd7fc6dea7a61764889"},
-    {file = "bitarray-2.7.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2ad866b82dd457239e2d0de864a09cc6efd4ccd2e0706314368835773e2b6018"},
-    {file = "bitarray-2.7.6-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:c9778c56a4f9cda3c61941ea95db279b52c38e9b9ad174d52fd7174f9ec44c46"},
-    {file = "bitarray-2.7.6-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:da810a6704723bbaae3d9d5a0c552c52e15f2b97aff599c5243464e04a9bc5ac"},
-    {file = "bitarray-2.7.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e38fe19d4f6ddc669f8a13fa21b482ec72bc32d2def6b97018dba4db53823848"},
-    {file = "bitarray-2.7.6-cp38-cp38-win32.whl", hash = "sha256:17c13936465e4dd2f4b58ce93f4d1fc92a684f1870830581bf950991e1e56eaa"},
-    {file = "bitarray-2.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:732642e9284a7dbaca00d8a4837f997462fc01e8207f2be598e179c3b51e20e2"},
-    {file = "bitarray-2.7.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1b8f439bf3939133ca2a12bfdc6fc2408b50099fd8fec88e5829f1eb9d49d636"},
-    {file = "bitarray-2.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:97496cca479e2b30a5c5354359f1fb85c4a0678b8d651656cc96a6ba3028bc94"},
-    {file = "bitarray-2.7.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7a8d697e201a2f9b16d292d7fa066b9bbc0123abd9058885e408db984a1b4776"},
-    {file = "bitarray-2.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:249e5d52785de2615264e579e25d85038e4bea9797e24e47b577e614c1187a2d"},
-    {file = "bitarray-2.7.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e1da9ebd148389bce250403c02ef1f1495984612db534072b0aa101fd051a0b"},
-    {file = "bitarray-2.7.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c237144123f1eb563c305d70634a97729716bfcd841f1519c33396e62d8ea3bd"},
-    {file = "bitarray-2.7.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e90774f5453c610a0b62f6d235120c459c1dc0f2c7e8b4871a14f2dcf4d74cc"},
-    {file = "bitarray-2.7.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07ac65cae21d79a4642a85109e40da48903c58fd14b7e42f31c48c37b7b8a37a"},
-    {file = "bitarray-2.7.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1eeeb25912fc4832546d328032e345d281720c2c73effd2234feb24045cfb10e"},
-    {file = "bitarray-2.7.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:37429158856fe0548786910ebc16e56606a60f01946f746cb7a6a78acf787711"},
-    {file = "bitarray-2.7.6-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:5ecdb1f22f9aae4405393cf845b1a43bbf786536fa673aae92745508ca8c84ef"},
-    {file = "bitarray-2.7.6-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:1bc7466820fae5376e2c0c9592e67ffd2a5fb1ab261942357ba23b5252b5eae5"},
-    {file = "bitarray-2.7.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:900cc391b38bf098f30ae5847c2df30f413b9311f27f13ced1818cbc28da928c"},
-    {file = "bitarray-2.7.6-cp39-cp39-win32.whl", hash = "sha256:17d2df5517ab961b6ce679c050884141439695a931539597fea76933891f04a0"},
-    {file = "bitarray-2.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:66ebfee12371d9cf7f59eb8964fcb1e711f075df6a2e29880c9aa8b55fa5bce4"},
-    {file = "bitarray-2.7.6-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:17df9b29105beec4dc4a489041783ddfe9de2628706bd4255863acfe3a78e648"},
-    {file = "bitarray-2.7.6-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffdb9106fd0d36b0a87db9903e3078877a9cdde98e064b76f24f6d8eb46067e6"},
-    {file = "bitarray-2.7.6-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:689859e796d39d0151d1d7a0f50b8119547cbd76d815884e8d8ff5e7e3ce8244"},
-    {file = "bitarray-2.7.6-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bff837274244e1dcf57e43820ccd8f95736ab30e7f5f0c79e81f655717060d37"},
-    {file = "bitarray-2.7.6-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ffd1d8edb67b8ca264e033a349b611426b5b84c3eec410aeb6df67b784450131"},
-    {file = "bitarray-2.7.6-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:915abc5db73dd2e15182bc2b281e0aa565124068a6f36f8237d3479804478ea8"},
-    {file = "bitarray-2.7.6-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90a246583ff481c869227058988f5d2cfe5dd5a6cf76596b6e8de88cc10d440a"},
-    {file = "bitarray-2.7.6-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24f7804bd40deba52fb14c5c1510273e6e4a084ef7c9896a30bd9ee5353dbc40"},
-    {file = "bitarray-2.7.6-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56e4f09d684337e33f6ad24bf4cda984de07b969865bfe2a8fd556ee1e1581cc"},
-    {file = "bitarray-2.7.6-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:bbb093c86e2c747ba3e81b01924353d982d4f6b62cce76a5eb1eb157cdf499e9"},
-    {file = "bitarray-2.7.6-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:13734e42f83a7ef75c876458619e11863f1d60644c83ff9a5ce21abf2935f331"},
-    {file = "bitarray-2.7.6-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439459b58ff0cd29883445662c5d80cee109c4ce5984001798bb74a31b1ac9e"},
-    {file = "bitarray-2.7.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:952170c03bc415719156594aed10c7b20ce7d4389551f6bc89969e23486d245c"},
-    {file = "bitarray-2.7.6-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a13774c45e9f59941b374a0e489f6660fcb4d027005748036a829cfab097c14"},
-    {file = "bitarray-2.7.6-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2d6a93eb2af22deba0e6f7353a68457fa04f933d59c6a0ca420759c0527850cd"},
-    {file = "bitarray-2.7.6.tar.gz", hash = "sha256:3807f9323c308bc3f9b58cbe5d04dc28f34ac32d852999334da96b42f64b5356"},
+    {file = "bitarray-2.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8d59ddee615c64a8c37c5bfd48ceea5b88d8808f90234e9154e1e209981a4683"},
+    {file = "bitarray-2.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd151c59b3756b05d8d616230211e0fb9ee10826b080f51f3e0bf85775027f8c"},
+    {file = "bitarray-2.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16b6144c30aa6661787a25e489335065e44fc4f74518e1e66e4591d669460516"},
+    {file = "bitarray-2.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8c607bfcb43c8230e24c18c368c9773cf37040fb14355ecbc51ad7b7b89be5a"},
+    {file = "bitarray-2.8.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7cd2df3c507ee85219b38e2812174ba8236a77a729f6d9ba3f66faed8661dc3b"},
+    {file = "bitarray-2.8.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:323d1b9710d1ef320c0b6c1f3d422355b8c371f4c898d0a9d9acb46586fd30d4"},
+    {file = "bitarray-2.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d4723b41afbd3574d3a72a383f80112aeceaeebbe6204b1e0ac8d4d7f2353b2"},
+    {file = "bitarray-2.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28dced57e7ee905f0a6287b6288d220d35d0c52ea925d2461b4eef5c16a40263"},
+    {file = "bitarray-2.8.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f4916b09f5dafe74133224956ce72399de1be7ca7b4726ce7bf8aac93f9b0ab6"},
+    {file = "bitarray-2.8.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:524b5898248b47a1f39cd54ab739e823bb6469d4b3619e84f246b654a2239262"},
+    {file = "bitarray-2.8.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:37fe92915561dd688ff450235ce75faa6679940c78f7e002ebc092aa71cadce9"},
+    {file = "bitarray-2.8.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:a13d7cfdbcc5604670abb1faaa8e2082b4ce70475922f07bbee3cd999b092698"},
+    {file = "bitarray-2.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ba2870bc136b2e76d02a64621e5406daf97b3a333287132344d4029d91ad4197"},
+    {file = "bitarray-2.8.0-cp310-cp310-win32.whl", hash = "sha256:432ff0eaf79414df582be023748d48c9b3a7d20cead494b7bc70a66cb62fb34f"},
+    {file = "bitarray-2.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb33df6bbe32d2146229e7ad885f654adc1484c7f734633e6dba2af88000b947"},
+    {file = "bitarray-2.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e1df5bc9768861178632dab044725ad305170161c08e9aa1d70b074287d5cbd3"},
+    {file = "bitarray-2.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ff04386b9868cc5961d95c84a8389f5fc4e3a2cbea52499a907deea13f16ae4"},
+    {file = "bitarray-2.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cd0a807a04e69aa9e4ea3314b43beb120dad231fce55c718aa00691595df628f"},
+    {file = "bitarray-2.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ddb75bd9bfbdff5231f0218e7cd4fd72653dc0c7baa782c3a95ff3dac4d5556"},
+    {file = "bitarray-2.8.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:599a57c5f0082311bccf7b35a3eaa4fdca7bf59179cb45958a6a418a9b8339d1"},
+    {file = "bitarray-2.8.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86a563fa4d2bfb2394ac21f71f8e8bb1d606d030b003398efe37c5323df664aa"},
+    {file = "bitarray-2.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:561e6b5a8f4498240f34de67dc672f7a6867c6f28681574a41dc73bb4451b0cb"},
+    {file = "bitarray-2.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d5fc3e73f189daf8f351fefdbad77a6f4edc5ad001aca4a541615322dbe8ee9"},
+    {file = "bitarray-2.8.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:84137be7d55bed08e3ef507b0bde8311290bf92fba5a9d05069b0d1910217f16"},
+    {file = "bitarray-2.8.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d6b0ce7a00a1b886e2410c20e089f3c701bc179429c681060419bbbf6ea263b7"},
+    {file = "bitarray-2.8.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:f06680947298dca47437a79660c69db6442570dd492e8066ab3bf7166246dee1"},
+    {file = "bitarray-2.8.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:b101a770d11b4fb0493e649cf3160d8de582e32e517ff3a7d024fad2e6ffe9e1"},
+    {file = "bitarray-2.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a83eedc91f88d31e1e7e386bd7bf65eacd5064af95d5b1ccd512bef3d516a4b"},
+    {file = "bitarray-2.8.0-cp311-cp311-win32.whl", hash = "sha256:1f90c59309f7208792f46d84adac58d8fdf6db3b1479b40e6386dd39a12950eb"},
+    {file = "bitarray-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:b70caaec1eece68411dfeded34466ad259e852ac4be8ee4001ee7dea4b37a5b2"},
+    {file = "bitarray-2.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:181394e0da1817d7a72a9b6cad6a77f6cfac5aa70007e21aadfa702fcf0d89eb"},
+    {file = "bitarray-2.8.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3636c073b501029256fda1546020b60e0af572a9a5b11f5c50c855113b1fbc"},
+    {file = "bitarray-2.8.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:40e6047a049595147518e6fe40759e609559799402efade093a3b67cda9e7ea9"},
+    {file = "bitarray-2.8.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:74dd172224a2e9fea2818a0d8c892b273fa6de434b953b97a2252572fcf01fb3"},
+    {file = "bitarray-2.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03425503093f28445b7e8c7df5faf2a704e32ee69c80e6dc5518ccea0b876ac9"},
+    {file = "bitarray-2.8.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:089c707a4997b49cd3a4fb9a4239a9b0aaac59cc937dfa84c9a6862f08634d6f"},
+    {file = "bitarray-2.8.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:1dfa4b66779ea4bba23ca655edbdd7e8c839daea160c6a1f1c1e6587fb8c79af"},
+    {file = "bitarray-2.8.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:8a6593023d03dc71f015efba1ce9319982a49add363050a3e298904ca19b60ef"},
+    {file = "bitarray-2.8.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:93c5937df1bfbfb17ee17c7717b49cbe04d88fa5d9dcfc1846914318dcf0135b"},
+    {file = "bitarray-2.8.0-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:67af0a5f32ec1de99c6baaa2359c47adac245fda20969c169da9b03dacb48fb7"},
+    {file = "bitarray-2.8.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:4b6650d05ebb92379465393bd279d298ff0a13fbf23bacbd1bcb20d202fccc67"},
+    {file = "bitarray-2.8.0-cp36-cp36m-win32.whl", hash = "sha256:b3381e75bb34ca0f455c4a0ac3625e5d9472f79914a3fd15ee1230584eab7d00"},
+    {file = "bitarray-2.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:951b39a515ed07487df02f0480617500f87b5e01cb36ec775dd30577633bec44"},
+    {file = "bitarray-2.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4e5c53500ee060c36303210d34df0e18636584ae1a70eb427e96fed70189896f"},
+    {file = "bitarray-2.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1deaaebbae83cf7b6fd252c36a4f03bd820bcf209da1ca400dddbf11064e35ec"},
+    {file = "bitarray-2.8.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:36eb9bdeee9c5988beca491741c4e2611abbea7fbbe3f4ebe35e00d509c40847"},
+    {file = "bitarray-2.8.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:143c9ac7a7f7e155f42bbf1fa547feaf9b4b2c226a25f17ae0d0d537ce9a328d"},
+    {file = "bitarray-2.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06984d12925e595a26da7855a5e868ce9b19b646e4b130e69a85bfcd6ce9227b"},
+    {file = "bitarray-2.8.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa54a847ae50050099e23ddc2bf20c7f2792706f95e997095e3551048841fc68"},
+    {file = "bitarray-2.8.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:dd5dcc4c26d7ef55934fcecea7ebd765313554d86747282c716fa64954cf103d"},
+    {file = "bitarray-2.8.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:706835e0e40b4707894af0ddd193eb8bbfb72835db8e4a8be7f6697ddc63c3eb"},
+    {file = "bitarray-2.8.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:216af36c9885a229d493ebdd5aa5648aae8db15b1c79ca6c2ad11b7f9bf4062f"},
+    {file = "bitarray-2.8.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:6f45bffd00892afa7e455990a9da0bbe0ac2bee978b4bdbb70439345f61b618a"},
+    {file = "bitarray-2.8.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e006e43ee096922cdaca797b313292a7ee29b43361da7d3d85d859455a0b6339"},
+    {file = "bitarray-2.8.0-cp37-cp37m-win32.whl", hash = "sha256:f00dc03d1c909712a14edafd7edeccf77aca1590928f02f29901d767153b95ef"},
+    {file = "bitarray-2.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1fdba2209df0ca379b5276dc48c189f424ec6701158a666876265b2669db9ed7"},
+    {file = "bitarray-2.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:741fc4eb77847b5f046559f77e0f822b3ce270774098f075bc712ef9f5c5948d"},
+    {file = "bitarray-2.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:66cf402bc4154a074d95f4dec3260497f637112fb982c2335d3bbc174d8c0a2d"},
+    {file = "bitarray-2.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:46fb5fbde325fd0bfcd9efd7ea3c5e2c1fd7117ad06e5cf37ca2c6dab539abc4"},
+    {file = "bitarray-2.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d6922dffc5e123e09907b79291951655ec0a2fde7c36a5584eb67c3b769d118"},
+    {file = "bitarray-2.8.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7885e5c23bb2954d913b4e8bb1486a7d2fbf69d27438ef096178eccf1d9e1e7a"},
+    {file = "bitarray-2.8.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:123d3802e7eafada61854d16c20d0df0c5f1d68da98f9e16059a23d200b5057a"},
+    {file = "bitarray-2.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6167bf10c3f773612a65b925edb4c8e002f1b826db6d3e91839153d6030fec17"},
+    {file = "bitarray-2.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:844e12f06e7167855c7db6838ea4ef08e44621dd4606039a4b5c0c6ca0801edf"},
+    {file = "bitarray-2.8.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:117d53e1ada8d7f9b8a350bb78597488311637c036da1a6aeb7071527672fdf7"},
+    {file = "bitarray-2.8.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:816510e83e61d1f44ff2f138863068451840314774bad1cc2911a1f86c93eb2f"},
+    {file = "bitarray-2.8.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3619bd30f163a3748325677996d4095b56ab1eb21610797f2b59f30e26ad1a7a"},
+    {file = "bitarray-2.8.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:f89cd1a17b57810b640344a559de60039bf50de36e0d577f6f72fab7c23ee023"},
+    {file = "bitarray-2.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:639f8ebaad5cec929dd73859d5ab850d4df746272754987720cf52fbbe2ec08e"},
+    {file = "bitarray-2.8.0-cp38-cp38-win32.whl", hash = "sha256:991dfaee77ecd82d96ddd85d242836de9471940dd89e943feea26549a9170ecb"},
+    {file = "bitarray-2.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:45c5e6d5970ade6f98e91341b47722c3d0d68742bf62e3d47b586897c447e78a"},
+    {file = "bitarray-2.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:62899c1102b47637757ad3448cb32caa4d4d8070986c29abe091711535644192"},
+    {file = "bitarray-2.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6897cd0c67c9433faca9023cb5eff25678e056764ce158998e6f30137e9a7f17"},
+    {file = "bitarray-2.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d0952c8417c21ea9eb2532475b2927753d6080f346f953a520e28794297d45f3"},
+    {file = "bitarray-2.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa6e51062a9eba797d97390a4c1f7941e489dd807b2de01d6a190d1a69eacf0a"},
+    {file = "bitarray-2.8.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8fb89f6b229ef8fa0e70d9206c57118c2f9bd98c54e3d73c4de00ab8147eed1c"},
+    {file = "bitarray-2.8.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc6b74eef97dc84acb429bb9c48363f88767f02b7d4a3e6dfd274334e0dc002e"},
+    {file = "bitarray-2.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00a7df14e82b0da37b47f51a1e6a053dbdccbad52627ae6ce6f2516e3ca7db13"},
+    {file = "bitarray-2.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5557e41cd92a9f05795980d762e9eca4dee3b393b8a005cb5e091d1e5c319181"},
+    {file = "bitarray-2.8.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:13dde9b590e27e9b8be9b96b1d697dbb19ca5c790b7d45a5ed310049fe9221b5"},
+    {file = "bitarray-2.8.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ebe2a6a8e714e5845fba173c05e26ca50616a7a7845c304f5c3ffccecda98c11"},
+    {file = "bitarray-2.8.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:0cd43f0943af45a1056f5dbdd10dc07f513d80ede72cac0306a342db6bf87d1d"},
+    {file = "bitarray-2.8.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:9a89b32c81e3e8a5f3fe9b458881ef03c1ba60829ae97999a15e86ea476489c6"},
+    {file = "bitarray-2.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b7bf3667e4cb9330b5dc5ae3753e833f398d12cbe14db1baf55cfd6a3ff0052d"},
+    {file = "bitarray-2.8.0-cp39-cp39-win32.whl", hash = "sha256:e28b9af8ebeeb19396b7836a06fc1b375a5867cff6a558f7d35420d428a3e2ad"},
+    {file = "bitarray-2.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:aabceebde1a450eb363a7ad7a531ab54992520f0a7386844bac7f700d00bb2d3"},
+    {file = "bitarray-2.8.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:90f3c63e44eb11424745453da1798ed6abcf6f467a92b75fda7b182cb1fb3e01"},
+    {file = "bitarray-2.8.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7aa632610fe03272e01fd006c9db2c102340344b034c9bd63e2ed9e3f895cc"},
+    {file = "bitarray-2.8.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11447698f2ae9ac6417d25222ab1e6ec087c32d603a9131b2c09ce0911766002"},
+    {file = "bitarray-2.8.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83f80d6f752d40d633c99c12d24d11774a6c3c3fd02dfd038a0496892fb15ed3"},
+    {file = "bitarray-2.8.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ee6df5243fcab8bb2bd14396556f1a28eebf94862bf14c1333ff309177ac62ba"},
+    {file = "bitarray-2.8.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0d19fd86aa02dbbec68ffb961a237a0bd2ecfbd92a6815fea9f20e9a3536bd92"},
+    {file = "bitarray-2.8.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40997802289d647952449b8bf0ee5c56f1f767e65ab33c63e8f756ba463343a7"},
+    {file = "bitarray-2.8.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bd66672c9695e75cf54d1f3f143a85e6b57078a7b86faf0de2c0c97736dfbb4"},
+    {file = "bitarray-2.8.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae79e0ed10cf221845e036bc7c3501e467a3bf288768941da1d8d6aaf12fec34"},
+    {file = "bitarray-2.8.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:18f7a8d4ebb8c8750e9aafbcfa1b2bfa9b6291baec6d4a31186762956f88cada"},
+    {file = "bitarray-2.8.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:eb45c7170c84c14d67978ccae74def18076a7e07cece0fc514078f4d5f8d0b71"},
+    {file = "bitarray-2.8.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d47baae8d5618cce60c20111a4ceafd6ed155e5501e0dc9fb9db55408e63e4a"},
+    {file = "bitarray-2.8.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc347f9a869a9c2b224bae65f9ed12bd1f7f97c0cbdfe47e520d6a7ba5aeec52"},
+    {file = "bitarray-2.8.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5618e50873f8a5ba96facbf61c5f342ee3212fee4b64c21061a89cb09df4428"},
+    {file = "bitarray-2.8.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f59f189ed38ad6fc3ef77a038eae75757b2fe0e3e869085c5db7472f59eaefb3"},
+    {file = "bitarray-2.8.0.tar.gz", hash = "sha256:cd69a926a3363e25e94a64408303283c59085be96d71524bdbe6bfc8da2e34e0"},
 ]
 
 [[package]]
@@ -480,14 +480,14 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]
@@ -728,29 +728,6 @@ files = [
 ]
 
 [[package]]
-name = "cosmpy"
-version = "0.6.0"
-description = "A library for interacting with the cosmos networks"
-category = "main"
-optional = false
-python-versions = ">=3.8,<4.0"
-files = [
-    {file = "cosmpy-0.6.0-py3-none-any.whl", hash = "sha256:fce96685e4fd85642ed48e448eb8f4a38871af506d1f150d8fd464f3947ce502"},
-    {file = "cosmpy-0.6.0.tar.gz", hash = "sha256:5d93847e92a30b724778f6263df7df8c9a193d5b819d25ece07aa85517436dd1"},
-]
-
-[package.dependencies]
-bech32 = "*"
-bip-utils = "*"
-blspy = "*"
-ecdsa = "*"
-google-api-python-client = "*"
-grpcio = "1.47.0"
-jsonschema = ">=4.16.0,<5.0.0"
-protobuf = ">=3.19.4,<4"
-requests = "*"
-
-[[package]]
 name = "coverage"
 version = "7.2.7"
 description = "Code coverage measurement for Python"
@@ -882,110 +859,105 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cytoolz"
-version = "0.12.1"
+version = "0.12.2"
 description = "Cython implementation of Toolz: High performance functional utilities"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "cytoolz-0.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c59bb4ca88e1c69931468bf21f91c8f64d8bf1999eb163b7a2df336f60c304a"},
-    {file = "cytoolz-0.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d700e011156ff112966c6d77faaae125fcaf538f4cec2b9ce8957de82858f0f"},
-    {file = "cytoolz-0.12.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23c3f57c48eb939d2986eba4aeaeedf930ebf94d58c91a42d4e0fc45ed5427dc"},
-    {file = "cytoolz-0.12.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25ff13c468c06da9ef26651dc389e7e8bb7af548f8c1dfb96305f57f18d398a8"},
-    {file = "cytoolz-0.12.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a734511144309ea6e105406633affb74e303a3df07d8a3954f9b01946e27ecb1"},
-    {file = "cytoolz-0.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48bc2f30d1b2646d675bb8e7778ab59379bf9edc59fe06fb0e7f85ba1271bf44"},
-    {file = "cytoolz-0.12.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30936ae8fa68b6a1ac8ad6c4bacb5a8a00d51bc6c89f9614a1557b0105d09f8a"},
-    {file = "cytoolz-0.12.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efd1b2da3ee577fcfa723a214f73186aef9674dd5b28242d90443c7a82722b0f"},
-    {file = "cytoolz-0.12.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6805b007af3557ee6c20dab491b6e55a8177f5b6845d9e6c653374d540366ba7"},
-    {file = "cytoolz-0.12.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:a6e63fc67b23830947b51e0a488992e3c904fce825ead565f3904dcf621d05f7"},
-    {file = "cytoolz-0.12.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:9e324a94856d88ecf10f34c102d0ded67d7c3cf644153d77e34a29720ce6aa47"},
-    {file = "cytoolz-0.12.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02975e2b1e61e47e9afa311f4c1783d155136fad37c54a1cebfe991c5a0798a1"},
-    {file = "cytoolz-0.12.1-cp310-cp310-win32.whl", hash = "sha256:b6569f6038133909cd658dbdcc6fc955f791dc47a7f5b55d2066f742253dcbfe"},
-    {file = "cytoolz-0.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:1be368623e46ad3c1ce807e7a436acb119c26001507b31f92ceb21b86e08c386"},
-    {file = "cytoolz-0.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:849f461bffa1e7700ccfcb5186df29cd4cdcc9efdb7199cb8b5681dc37045d72"},
-    {file = "cytoolz-0.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4284120c978fb7039901bf6e66832cb3e82ac1b2a107512e735bdb04fd5533ed"},
-    {file = "cytoolz-0.12.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ec296f01c29c809698eaf677211b6255691295c2b35caab2131e1e7eaadfbac"},
-    {file = "cytoolz-0.12.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37c53f456a1c84566a7d911eec57c4c6280b915ab0600e7671582793cc2769fe"},
-    {file = "cytoolz-0.12.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1b6761791973b1e839b8309d5853b40eeb413368e31beaf5f2b6ed44c6fc7cf0"},
-    {file = "cytoolz-0.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff478682e8ee6dbaa37201bb71bf4a6eee744006ab000e8f5cea05066fc7c845"},
-    {file = "cytoolz-0.12.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:867bebe6be30ee36a836f9b835790762a74f46be8cc339ea57b68dcecdbc1133"},
-    {file = "cytoolz-0.12.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7e903df991f0957e2b271a37bb25d28e0d260c52825ae67507d15ca55a935961"},
-    {file = "cytoolz-0.12.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e797c4afb1b7962d3205b1959e1051f7e6bfbba29da44042a9efc2391f1feb38"},
-    {file = "cytoolz-0.12.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b8eceaa12b7f152b046b67cb053ec2b5b00f73593983de69bc5e63a8aca4a7a8"},
-    {file = "cytoolz-0.12.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:b575393dd431b8e211de35bd593d831dac870172b16e2b7934f3566b8fc89377"},
-    {file = "cytoolz-0.12.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3032c0ba42dee5836d6b57a72a569b65df2c29e8ed266cb900d569003cf933a9"},
-    {file = "cytoolz-0.12.1-cp311-cp311-win32.whl", hash = "sha256:c576bd63495150385b8d05eaae775387f378be2fd9805d3ffb4d17c87271fbad"},
-    {file = "cytoolz-0.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:421b224dc4157a0d66625acb5798cf50858cfa06a5232d39a8bd6cf1fa88aca3"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:be5a454a95797343d0fb1ed02caecae73a023b1393c112951c84f17ec9f4076c"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:061387aa39b9c1576c25d0c59142513c09e77a2a07bd5d6211a43c7a758b6f45"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14f4dbc3f0ec8f6fc68865489af21dcf042ff007d2737c27bfd73296f15db544"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a816bff6bf424753e1ac2441902ceaf37ae6718b745a53f6aa1a60c617fb4f5f"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:633f19d1990b1cf9c67dce9c28bf8b5a18e42785d15548607a100e1236384d5d"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fa7009c843667868aa8bdb3d68e5ef3d6356dd418b17ed5ca4e1340e82483a5"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:1c29dd04e282ddfd45b457e3551075beec9128aa9271245e58ce924bf6e055f8"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:cd35c0be4c46274129dd1678bb911dd4e93d23968b26f4e39cd55bc7cb3b1bac"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:5158ae6d8dd112d003f677039a3613ca7d2592bfe35d7accf23684edb961fc26"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:7eb9e6fa8a82c3d2f519f7d3942898a97792e3895569e9501b9431048289b82f"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ac6784cc43aec51a86cf9058a2a343084f8cf46a9281bea5762bfa608127c53b"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-win32.whl", hash = "sha256:794cce219bbcb2f36ca220f27d5afd64eaa854e04901bd6f240be156a578b607"},
-    {file = "cytoolz-0.12.1-cp36-cp36m-win_amd64.whl", hash = "sha256:695dd8231e4f1bfb9a2363775a6e4e56ad9d2058058f817203a49614f4bfe33b"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1bd8017ef0da935a20106272c5f5ff6b1114add1ccb09cfed1ff7ec5cc01c6d"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56e1ebf6eb4438b8c45cbe7e7b22fc65df0c9efa97a70d3bf2f51e08b19756a5"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:816c2038008ebf50d81171ddfae377f1af9e71d504ec609469dcb0906bfcf2ae"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bebe58f7a160db7838eb70990c704db4bdc2d58bd364290fd69be0587be8bac"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a72440305f634604827f96810e4469877b89f5c060d6852267650a49b0e3768c"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b46ebc463bb45f278a2b94e630061c26e10077cb68d4c93583d8f4199699a5ef"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e75e287787e6adafed9d8c3d3e7647c0b5eb460221f9f92d7dfe48b45ba77c0d"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:03ab22c9aeb1535f8647d23b6520b0c3d41aaa18d04ef42b352dde1931f2e2b1"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:b2ac288f27a2689d9e39f4cf4df5437a8eb038eaae515169586c77f9f8fb343a"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:97a24c0d0806fcf9a6e75fc18aeb95adc37eb0baf6451f10a2de23ffd815329d"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:42c9e5cd2a48a257b1f2402334b48122501f249b8dcf77082f569f2680f185eb"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-win32.whl", hash = "sha256:35fae4eaa0eaf9072a5fe2d244a79e65baae4e5ddbe9cc629c5037af800213a2"},
-    {file = "cytoolz-0.12.1-cp37-cp37m-win_amd64.whl", hash = "sha256:5af43ca7026ead3dd08b261e4f7163cd2cf3ceaa74fa5a81f7b7ea5d445e41d6"},
-    {file = "cytoolz-0.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fcc378fa97f02fbcef090b3611305425d72bd1c0afdd13ef4a82dc67d40638b6"},
-    {file = "cytoolz-0.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc3645cf6b9246cb8e179db2803e4f0d148211d2a2cf22d5c9b5219111cd91a0"},
-    {file = "cytoolz-0.12.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b245b824f4705aef0e4a03fafef3ad6cb59ef43cc564cdbf683ee28dfc11ad5"},
-    {file = "cytoolz-0.12.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c1964dcb5f250fd13fac210944b20810d61ef4094a17fbbe502ab7a7eaeeace7"},
-    {file = "cytoolz-0.12.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f7194a22a4a24f3561cb6ad1cca9c9b2f2cf34cc8d4bce6d6a24c80960323fa8"},
-    {file = "cytoolz-0.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1c5434db53f3a94a37ad8aedb231901e001995d899af6ed1165f3d27fa04a6a"},
-    {file = "cytoolz-0.12.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b30cd083ef8af4ba66d9fe5cc75c653ede3f2655f97a032db1a14cc8a006719c"},
-    {file = "cytoolz-0.12.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bef934bd3e024d512c6c0ad1c66eb173f61d9ccb4dbca8d75f727a5604f7c2f6"},
-    {file = "cytoolz-0.12.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:37320669c364f7d370392af33cc1034b4563da66c22cd3261e3530f4d30dbe4b"},
-    {file = "cytoolz-0.12.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3cb95d23defb2322cddf70efb4af6dac191d95edaa343e8c1f58f1afa4f92ecd"},
-    {file = "cytoolz-0.12.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ac5895d5f78dbd8646fe37266655ba4995f9cfec38a86595282fee69e41787da"},
-    {file = "cytoolz-0.12.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:499af2aff04f65b4c23de1df08e1d1484a93b23ddaaa0163e44b5070b68356eb"},
-    {file = "cytoolz-0.12.1-cp38-cp38-win32.whl", hash = "sha256:aa61e3da751a2dfe95aeca603f3ef510071a136ba9905f61ae6cb5d0696271ad"},
-    {file = "cytoolz-0.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:f5b43ce952a5a31441556c55f5f5f5a8e62c28581a0ff2a2c31c04ef992d73bd"},
-    {file = "cytoolz-0.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b8b8f88251b84b3877254cdd59c86a1dc6b2b39a03c6c9c067d344ef879562e0"},
-    {file = "cytoolz-0.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d72415b0110f7958dd3a5ee98a70166f47bd42ede85e3535669c794d06f57406"},
-    {file = "cytoolz-0.12.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8101ab6de5aa0b26a2b5032bc488d430010c91863e701812d65836b03a12f61"},
-    {file = "cytoolz-0.12.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2eed428b5e68c28abf2c71195e799850e040d67a27c05f7785319c611665b86a"},
-    {file = "cytoolz-0.12.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:59641eb1f41cb688b3cb2f98c9003c493a5024325f76b5c02333d08dd972127c"},
-    {file = "cytoolz-0.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a48940ff0449ffcf690310bf9228bb57885f7571406ed2fe05c98e299987195"},
-    {file = "cytoolz-0.12.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bae431a5985cdb2014be09d37206c288e0d063940cf9539e9769bd2ec26b220"},
-    {file = "cytoolz-0.12.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cb8b10405960a8e6801a4702af98ea640130ec6ecfc1208195762de3f5503ba9"},
-    {file = "cytoolz-0.12.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3c9a16a5b4f54d5c0a131f56b0ca65998a9a74958b5b36840c280edba4f8b907"},
-    {file = "cytoolz-0.12.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:49911cb533c96d275e31e7eaeb0742ac3f7afe386a1d8c40937814d75039a0f7"},
-    {file = "cytoolz-0.12.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:dbae37d48ef5a0ab90cfaf2b9312d96f034b1c828208a9cbe25377a1b19ba129"},
-    {file = "cytoolz-0.12.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c34e69be4429633fc614febe3127fa03aa418a1abb9252f29d9ba5b3394573a5"},
-    {file = "cytoolz-0.12.1-cp39-cp39-win32.whl", hash = "sha256:0d474dacbafbdbb44c7de986bbf71ff56ae62df0d52ab3b6fa966784dc88737a"},
-    {file = "cytoolz-0.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:3d6d0b0075731832343eb88229cea4bf39e96f3fc7acbc449aadbdfec2842703"},
-    {file = "cytoolz-0.12.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8506d1863f30d26f577c4ed59d2cfd03d2f39569f9cbaa02a764a9de73d312d5"},
-    {file = "cytoolz-0.12.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a1eae39656a1685e8b3f433eecfd72015ce5c1d7519e9c8f9402153c68331bb"},
-    {file = "cytoolz-0.12.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a0055943074c6c85b77fcc3f42f7c54010a3478daa2ed9d6243d0411c84a4d3"},
-    {file = "cytoolz-0.12.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a7a325b8fe885a6dd91093616c703134f2dacbd869bc519970df3849c2a15b"},
-    {file = "cytoolz-0.12.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:7b60caf0fa5f1b49f1062f7dc0f66c7b23e2736bad50fa8296bfb845995e3051"},
-    {file = "cytoolz-0.12.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:980e7eb7205e01816a92f3290cfc80507957e64656b9271a0dfebb85fe3718c0"},
-    {file = "cytoolz-0.12.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d38a40fe153f23cda0e823413fe9d9ebee89dd461827285316eff929fb121e"},
-    {file = "cytoolz-0.12.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d540e9c34a61b53b6a374ea108794a48388178f7889d772e364cdbd6df37774c"},
-    {file = "cytoolz-0.12.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:117871f036926e42d3abcee587eafa9dc7383f1064ac53a806d33e76604de311"},
-    {file = "cytoolz-0.12.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:31131b54a0c72efc0eb432dc66df546c6a54f2a7d396c9a34cf65ac1c26b1df8"},
-    {file = "cytoolz-0.12.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4534cbfad73cdb1a6dad495530d4186d57d73089c01e9cb0558caab50e46cb3b"},
-    {file = "cytoolz-0.12.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50db41e875e36aec11881b8b12bc69c6f4836b7dd9e88a9e5bbf26c2cb3ba6cd"},
-    {file = "cytoolz-0.12.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6716855f9c669c9e25a185d88e0f169839bf8553d16496796325acd114607c11"},
-    {file = "cytoolz-0.12.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f32452e833f0605b871626e6c61b71b0cba24233aad0e04accc3240497d4995"},
-    {file = "cytoolz-0.12.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ba74c239fc6cb6e962eabc420967c7565f3f363b776c89b3df5234caecf1f463"},
-    {file = "cytoolz-0.12.1.tar.gz", hash = "sha256:fc33909397481c90de3cec831bfb88d97e220dc91939d996920202f184b4648e"},
+    {file = "cytoolz-0.12.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bff49986c9bae127928a2f9fd6313146a342bfae8292f63e562f872bd01b871"},
+    {file = "cytoolz-0.12.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:908c13f305d34322e11b796de358edaeea47dd2d115c33ca22909c5e8fb036fd"},
+    {file = "cytoolz-0.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:735147aa41b8eeb104da186864b55e2a6623c758000081d19c93d759cd9523e3"},
+    {file = "cytoolz-0.12.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7d352d4de060604e605abdc5c8a5d0429d5f156cb9866609065d3003454d4cea"},
+    {file = "cytoolz-0.12.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:89247ac220031a4f9f689688bcee42b38fd770d4cce294e5d914afc53b630abe"},
+    {file = "cytoolz-0.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9070ae35c410d644e6df98a8f69f3ed2807e657d0df2a26b2643127cbf6944a5"},
+    {file = "cytoolz-0.12.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:843500cd3e4884b92fd4037912bc42d5f047108d2c986d36352e880196d465b0"},
+    {file = "cytoolz-0.12.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6a93644d7996fd696ab7f1f466cd75d718d0a00d5c8118b9fe8c64231dc1f85e"},
+    {file = "cytoolz-0.12.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:96796594c770bc6587376e74ddc7d9c982d68f47116bb69d90873db5e0ea88b6"},
+    {file = "cytoolz-0.12.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:48425107fbb1af3f0f2410c004f16be10ffc9374358e5600b57fa543f46f8def"},
+    {file = "cytoolz-0.12.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:cde6dbb788a4cbc4a80a72aa96386ba4c2b17bdfff3ace0709799adbe16d6476"},
+    {file = "cytoolz-0.12.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:68ae7091cc73a752f0b938f15bb193de80ca5edf5ae2ea6360d93d3e9228357b"},
+    {file = "cytoolz-0.12.2-cp310-cp310-win32.whl", hash = "sha256:997b7e0960072f6bb445402da162f964ea67387b9f18bda2361edcc026e13597"},
+    {file = "cytoolz-0.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:663911786dcde3e4a5d88215c722c531c7548903dc07d418418c0d1c768072c0"},
+    {file = "cytoolz-0.12.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a7d8b869ded171f6cdf584fc2fc6ae03b30a0e1e37a9daf213a59857a62ed90"},
+    {file = "cytoolz-0.12.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9b28787eaf2174e68f0acb3c66f9c6b98bdfeb0930c0d0b08e1941c7aedc8d27"},
+    {file = "cytoolz-0.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00547da587f124b32b072ce52dd5e4b37cf199fedcea902e33c67548523e4678"},
+    {file = "cytoolz-0.12.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:275d53fd769df2102d6c9fc98e553bd8a9a38926f54d6b20cf29f0dd00bf3b75"},
+    {file = "cytoolz-0.12.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5556acde785a61d4cf8b8534ae109b023cbd2f9df65ee2afbe070be47c410f8c"},
+    {file = "cytoolz-0.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b41a85b9b9a2530b72b0d3d10e383fc3c2647ae88169d557d5e216f881860318"},
+    {file = "cytoolz-0.12.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:673d6e9e3aa86949343b46ac2b7be266c36e07ce77fa1d40f349e6987a814d6e"},
+    {file = "cytoolz-0.12.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:81e6a9a8fda78a2f4901d2915b25bf620f372997ca1f20a14f7cefef5ad6f6f4"},
+    {file = "cytoolz-0.12.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:fa44215bc31675a6380cd896dadb7f2054a7b94cfb87e53e52af844c65406a54"},
+    {file = "cytoolz-0.12.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a08b4346350660799d81d4016e748bcb134a9083301d41f9618f64a6077f89f2"},
+    {file = "cytoolz-0.12.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:2fb740482794a72e2e5fec58e4d9b00dcd5a60a8cef68431ff12f2ba0e0d9a7e"},
+    {file = "cytoolz-0.12.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9007bb1290c79402be6b84bcf9e7a622a073859d61fcee146dc7bc47afe328f3"},
+    {file = "cytoolz-0.12.2-cp311-cp311-win32.whl", hash = "sha256:a973f5286758f76824ecf19ae1999f6697371a9121c8f163295d181d19a819d7"},
+    {file = "cytoolz-0.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:1ce324d1b413636ea5ee929f79637821f13c9e55e9588f38228947294944d2ed"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c08094b9e5d1b6dfb0845a0253cc2655ca64ce70d15162dfdb102e28c8993493"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baf020f4b708f800b353259cd7575e335a79f1ac912d9dda55b2aa0bf3616e42"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4416ee86a87180b6a28e7483102c92debc077bec59c67eda8cc63fc52a218ac0"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6ee222671eed5c5b16a5ad2aea07f0a715b8b199ee534834bc1dd2798f1ade7"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad92e37be0b106fdbc575a3a669b43b364a5ef334495c9764de4c2d7541f7a99"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:460c05238fbfe6d848141669d17a751a46c923f9f0c9fd8a3a462ab737623a44"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9e5075e30be626ef0f9bedf7a15f55ed4d7209e832bc314fdc232dbd61dcbf44"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:03b58f843f09e73414e82e57f7e8d88f087eaabf8f276b866a40661161da6c51"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:5e4e612b7ecc9596e7c859cd9e0cd085e6d0c576b4f0d917299595eb56bf9c05"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:08a0e03f287e45eb694998bb55ac1643372199c659affa8319dfbbdec7f7fb3c"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b029bdd5a8b6c9a7c0e8fdbe4fc25ffaa2e09b77f6f3462314696e3a20511829"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-win32.whl", hash = "sha256:18580d060fa637ff01541640ecde6de832a248df02b8fb57e6dd578f189d62c7"},
+    {file = "cytoolz-0.12.2-cp36-cp36m-win_amd64.whl", hash = "sha256:97cf514a9f3426228d8daf880f56488330e4b2948a6d183a106921217850d9eb"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18a0f838677f9510aef0330c0096778dd6406d21d4ff9504bf79d85235a18460"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb081b2b02bf4405c804de1ece6f904916838ab0e057f1446e4ac12fac827960"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57233e1600560ceb719bed759dc78393edd541b9a3e7fefc3079abd83c26a6ea"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0295289c4510efa41174850e75bc9188f82b72b1b54d0ea57d1781729c2924d5"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a92aab8dd1d427ac9bc7480cfd3481dbab0ef024558f2f5a47de672d8a5ffaa"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51d3495235af09f21aa92a7cdd51504bda640b108b6be834448b774f52852c09"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f9c690b359f503f18bf1c46a6456370e4f6f3fc4320b8774ae69c4f85ecc6c94"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:481e3129a76ea01adcc0e7097ccb8dbddab1cfc40b6f0e32c670153512957c0f"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:55e94124af9c8fbb1df54195cc092688fdad0765641b738970b6f1d5ea72e776"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:5616d386dfbfba7c39e9418ba668c734f6ceaacc0130877e8a100cad11e6838b"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:732d08228fa8d366fec284f7032cc868d28a99fa81fc71e3adf7ecedbcf33a0f"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-win32.whl", hash = "sha256:f039c5373f7b314b151432c73219216857b19ab9cb834f0eb5d880f74fc7851c"},
+    {file = "cytoolz-0.12.2-cp37-cp37m-win_amd64.whl", hash = "sha256:246368e983eaee9851b15d7755f82030eab4aa82098d2a34f6bef9c689d33fcc"},
+    {file = "cytoolz-0.12.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:81074edf3c74bc9bd250d223408a5df0ff745d1f7a462597536cd26b9390e2d6"},
+    {file = "cytoolz-0.12.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:960d85ebaa974ecea4e71fa56d098378fa51fd670ee744614cbb95bf95e28fc7"},
+    {file = "cytoolz-0.12.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c8d0dff4865da54ae825d43e1721925721b19f3b9aca8e730c2ce73dee2c630"},
+    {file = "cytoolz-0.12.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a9d12436fd64937bd2c9609605f527af7f1a8db6e6637639b44121c0fe715d6"},
+    {file = "cytoolz-0.12.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd461e402e24929d866f05061d2f8337e3a8456e75e21b72c125abff2477c7f7"},
+    {file = "cytoolz-0.12.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0568d4da0a9ee9f9f5ab318f6501557f1cfe26d18c96c8e0dac7332ae04c6717"},
+    {file = "cytoolz-0.12.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:101b5bd32badfc8b1f9c7be04ba3ae04fb47f9c8736590666ce9449bff76e0b1"},
+    {file = "cytoolz-0.12.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8bb624dbaef4661f5e3625c1e39ad98ecceef281d1380e2774d8084ad0810275"},
+    {file = "cytoolz-0.12.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3e993804e6b04113d61fdb9541b6df2f096ec265a506dad7437517470919c90f"},
+    {file = "cytoolz-0.12.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ab911033e5937fc221a2c165acce7f66ae5ac9d3e54bec56f3c9c197a96be574"},
+    {file = "cytoolz-0.12.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6de6a4bdfaee382c2de2a3580b3ae76fce6105da202bbd835e5efbeae6a9c6e"},
+    {file = "cytoolz-0.12.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9480b4b327be83c4d29cb88bcace761b11f5e30198ffe2287889455c6819e934"},
+    {file = "cytoolz-0.12.2-cp38-cp38-win32.whl", hash = "sha256:4180b2785d1278e6abb36a72ac97c92432db53fa2df00ee943d2c15a33627d31"},
+    {file = "cytoolz-0.12.2-cp38-cp38-win_amd64.whl", hash = "sha256:d0086ba8d41d73647b13087a3ca9c020f6bfec338335037e8f5172b4c7c8dce5"},
+    {file = "cytoolz-0.12.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d29988bde28a90a00367edcf92afa1a2f7ecf43ea3ae383291b7da6d380ccc25"},
+    {file = "cytoolz-0.12.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:24c0d71e9ac91f4466b1bd280f7de43aa4d94682daaf34d85d867a9b479b87cc"},
+    {file = "cytoolz-0.12.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa436abd4ac9ca71859baf5794614e6ec8fa27362f0162baedcc059048da55f7"},
+    {file = "cytoolz-0.12.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45c7b4eac7571707269ebc2893facdf87e359cd5c7cfbfa9e6bd8b33fb1079c5"},
+    {file = "cytoolz-0.12.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:294d24edc747ef4e1b28e54365f713becb844e7898113fafbe3e9165dc44aeea"},
+    {file = "cytoolz-0.12.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:478051e5ef8278b2429864c8d148efcebdc2be948a61c9a44757cd8c816c98f5"},
+    {file = "cytoolz-0.12.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14108cafb140dd68fdda610c2bbc6a37bf052cd48cfebf487ed44145f7a2b67f"},
+    {file = "cytoolz-0.12.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5fef7b602ccf8a3c77ab483479ccd7a952a8c5bb1c263156671ba7aaa24d1035"},
+    {file = "cytoolz-0.12.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9bf51354e15520715f068853e6ab8190e77139940e8b8b633bdb587956a08fb0"},
+    {file = "cytoolz-0.12.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:388f840fd911d61a96e9e595eaf003f9dc39e847c9060b8e623ab29e556f009b"},
+    {file = "cytoolz-0.12.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:a67f75cc51a2dc7229a8ac84291e4d61dc5abfc8940befcf37a2836d95873340"},
+    {file = "cytoolz-0.12.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:63b31345e20afda2ae30dba246955517a4264464d75e071fc2fa641e88c763ec"},
+    {file = "cytoolz-0.12.2-cp39-cp39-win32.whl", hash = "sha256:f6e86ac2b45a95f75c6f744147483e0fc9697ce7dfe1726083324c236f873f8b"},
+    {file = "cytoolz-0.12.2-cp39-cp39-win_amd64.whl", hash = "sha256:5998f81bf6a2b28a802521efe14d9fc119f74b64e87b62ad1b0e7c3d8366d0c7"},
+    {file = "cytoolz-0.12.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:593e89e2518eaf81e96edcc9ef2c5fca666e8fc922b03d5cb7a7b8964dbee336"},
+    {file = "cytoolz-0.12.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff451d614ca1d4227db0ffa627fb51df71968cf0d9baf0210528dad10fdbc3ab"},
+    {file = "cytoolz-0.12.2-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad9ea4a50d2948738351790047d45f2b1a023facc01bf0361988109b177e8b2f"},
+    {file = "cytoolz-0.12.2-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbe038bb78d599b5a29d09c438905defaa615a522bc7e12f8016823179439497"},
+    {file = "cytoolz-0.12.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d494befe648c13c98c0f3d56d05489c839c9228a32f58e9777305deb6c2c1cee"},
+    {file = "cytoolz-0.12.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c26805b6c8dc8565ed91045c44040bf6c0fe5cb5b390c78cd1d9400d08a6cd39"},
+    {file = "cytoolz-0.12.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df4e32badb2ccf1773e1e74020b7e3b8caf9e92f842c6be7d14888ecdefc2c6c"},
+    {file = "cytoolz-0.12.2-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce7889dc3701826d519ede93cdff11940fb5567dbdc165dce0e78047eece02b7"},
+    {file = "cytoolz-0.12.2-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c820608e7077416f766b148d75e158e454881961881b657cff808529d261dd24"},
+    {file = "cytoolz-0.12.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:698da4fa1f7baeea0607738cb1f9877ed1ba50342b29891b0223221679d6f729"},
+    {file = "cytoolz-0.12.2.tar.gz", hash = "sha256:31d4b0455d72d914645f803d917daf4f314d115c70de0578d3820deb8b101f66"},
 ]
 
 [package.dependencies]
@@ -1426,14 +1398,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.94.0"
+version = "2.95.0"
 description = "Google API Client Library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-python-client-2.94.0.tar.gz", hash = "sha256:4ff598b7b83d5c0c5582927e74947286070b5b21a13e1bb64409fd92e45bfb26"},
-    {file = "google_api_python_client-2.94.0-py2.py3-none-any.whl", hash = "sha256:28b2f0c2c6380a119e2efd7ecd28fa9d313becf37d71f00bfa49332428e071b4"},
+    {file = "google-api-python-client-2.95.0.tar.gz", hash = "sha256:d2731ede12f79e53fbe11fdb913dfe986440b44c0a28431c78a8ec275f4c1541"},
+    {file = "google_api_python_client-2.95.0-py2.py3-none-any.whl", hash = "sha256:a8aab2da678f42a01f2f52108f787fef4310f23f9dd917c4e64664c3f0c885ba"},
 ]
 
 [package.dependencies]
@@ -1544,65 +1516,65 @@ files = [
 
 [[package]]
 name = "grpcio"
-version = "1.47.0"
+version = "1.47.5"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "grpcio-1.47.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:544da3458d1d249bb8aed5504adf3e194a931e212017934bf7bfa774dad37fb3"},
-    {file = "grpcio-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:b88bec3f94a16411a1e0336eb69f335f58229e45d4082b12d8e554cedea97586"},
-    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:06c0739dff9e723bca28ec22301f3711d85c2e652d1c8ae938aa0f7ad632ef9a"},
-    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4508e8abd67ebcccd0fbde6e2b1917ba5d153f3f20c1de385abd8722545e05f"},
-    {file = "grpcio-1.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9723784cf264697024778dcf4b7542c851fe14b14681d6268fb984a53f76df1"},
-    {file = "grpcio-1.47.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1bb9afa85e797a646bfcd785309e869e80a375c959b11a17c9680abebacc0cb0"},
-    {file = "grpcio-1.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4d9ad7122f60157454f74a850d1337ba135146cef6fb7956d78c7194d52db0fe"},
-    {file = "grpcio-1.47.0-cp310-cp310-win32.whl", hash = "sha256:0425b5577be202d0a4024536bbccb1b052c47e0766096e6c3a5789ddfd5f400d"},
-    {file = "grpcio-1.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:d0d481ff55ea6cc49dab2c8276597bd4f1a84a8745fedb4bc23e12e9fb9d0e45"},
-    {file = "grpcio-1.47.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:5f57b9b61c22537623a5577bf5f2f970dc4e50fac5391090114c6eb3ab5a129f"},
-    {file = "grpcio-1.47.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:14d2bc74218986e5edf5527e870b0969d63601911994ebf0dce96288548cf0ef"},
-    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:c79996ae64dc4d8730782dff0d1daacc8ce7d4c2ba9cef83b6f469f73c0655ce"},
-    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a24b50810aae90c74bbd901c3f175b9645802d2fbf03eadaf418ddee4c26668"},
-    {file = "grpcio-1.47.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55782a31ec539f15b34ee56f19131fe1430f38a4be022eb30c85e0b0dcf57f11"},
-    {file = "grpcio-1.47.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:35dfd981b03a3ec842671d1694fe437ee9f7b9e6a02792157a2793b0eba4f478"},
-    {file = "grpcio-1.47.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:664a270d3eac68183ad049665b0f4d0262ec387d5c08c0108dbcfe5b351a8b4d"},
-    {file = "grpcio-1.47.0-cp36-cp36m-win32.whl", hash = "sha256:9298d6f2a81f132f72a7e79cbc90a511fffacc75045c2b10050bb87b86c8353d"},
-    {file = "grpcio-1.47.0-cp36-cp36m-win_amd64.whl", hash = "sha256:815089435d0f113719eabf105832e4c4fa1726b39ae3fb2ca7861752b0f70570"},
-    {file = "grpcio-1.47.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:7191ffc8bcf8a630c547287ab103e1fdf72b2e0c119e634d8a36055c1d988ad0"},
-    {file = "grpcio-1.47.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:1ec63bbd09586e5cda1bdc832ae6975d2526d04433a764a1cc866caa399e50d4"},
-    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:08307dc5a6ac4da03146d6c00f62319e0665b01c6ffe805cfcaa955c17253f9c"},
-    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:668350ea02af018ca945bd629754d47126b366d981ab88e0369b53bc781ffb14"},
-    {file = "grpcio-1.47.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64e097dd08bb408afeeaee9a56f75311c9ca5b27b8b0278279dc8eef85fa1051"},
-    {file = "grpcio-1.47.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0d8a7f3eb6f290189f48223a5f4464c99619a9de34200ce80d5092fb268323d2"},
-    {file = "grpcio-1.47.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f89de64d9eb3478b188859214752db50c91a749479011abd99e248550371375f"},
-    {file = "grpcio-1.47.0-cp37-cp37m-win32.whl", hash = "sha256:67cd275a651532d28620eef677b97164a5438c5afcfd44b15e8992afa9eb598c"},
-    {file = "grpcio-1.47.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f515782b168a4ec6ea241add845ccfebe187fc7b09adf892b3ad9e2592c60af1"},
-    {file = "grpcio-1.47.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:91cd292373e85a52c897fa5b4768c895e20a7dc3423449c64f0f96388dd1812e"},
-    {file = "grpcio-1.47.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:a278d02272214ec33f046864a24b5f5aab7f60f855de38c525e5b4ef61ec5b48"},
-    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:bfdb8af4801d1c31a18d54b37f4e49bb268d1f485ecf47f70e78d56e04ff37a7"},
-    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e63e0619a5627edb7a5eb3e9568b9f97e604856ba228cc1d8a9f83ce3d0466e"},
-    {file = "grpcio-1.47.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc34d182c4fd64b6ff8304a606b95e814e4f8ed4b245b6d6cc9607690e3ef201"},
-    {file = "grpcio-1.47.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a6b2432ac2353c80a56d9015dfc5c4af60245c719628d4193ecd75ddf9cd248c"},
-    {file = "grpcio-1.47.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fcd5d932842df503eb0bf60f9cc35e6fe732b51f499e78b45234e0be41b0018d"},
-    {file = "grpcio-1.47.0-cp38-cp38-win32.whl", hash = "sha256:43857d06b2473b640467467f8f553319b5e819e54be14c86324dad83a0547818"},
-    {file = "grpcio-1.47.0-cp38-cp38-win_amd64.whl", hash = "sha256:96cff5a2081db82fb710db6a19dd8f904bdebb927727aaf4d9c427984b79a4c1"},
-    {file = "grpcio-1.47.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:68b5e47fcca8481f36ef444842801928e60e30a5b3852c9f4a95f2582d10dcb2"},
-    {file = "grpcio-1.47.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0cd44d78f302ff67f11a8c49b786c7ccbed2cfef6f4fd7bb0c3dc9255415f8f7"},
-    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:4706c78b0c183dca815bbb4ef3e8dd2136ccc8d1699f62c585e75e211ad388f6"},
-    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:324e363bad4d89a8ec7124013371f268d43afd0ac0fdeec1b21c1a101eb7dafb"},
-    {file = "grpcio-1.47.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b821403907e865e8377af3eee62f0cb233ea2369ba0fcdce9505ca5bfaf4eeb3"},
-    {file = "grpcio-1.47.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2061dbe41e43b0a5e1fd423e8a7fb3a0cf11d69ce22d0fac21f1a8c704640b12"},
-    {file = "grpcio-1.47.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8dbef03853a0dbe457417c5469cb0f9d5bf47401b49d50c7dad3c495663b699b"},
-    {file = "grpcio-1.47.0-cp39-cp39-win32.whl", hash = "sha256:090dfa19f41efcbe760ae59b34da4304d4be9a59960c9682b7eab7e0b6748a79"},
-    {file = "grpcio-1.47.0-cp39-cp39-win_amd64.whl", hash = "sha256:55cd8b13c5ef22003889f599b8f2930836c6f71cd7cf3fc0196633813dc4f928"},
-    {file = "grpcio-1.47.0.tar.gz", hash = "sha256:5dbba95fab9b35957b4977b8904fc1fa56b302f9051eff4d7716ebb0c087f801"},
+    {file = "grpcio-1.47.5-cp310-cp310-linux_armv7l.whl", hash = "sha256:acc73289d0c44650aa1f21eccfa967f5623b01c3b5e2b4596fe5f9c5bf10956d"},
+    {file = "grpcio-1.47.5-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:f3174c798959998876d546944523a558f78a9b9feb22a2cbaaa3822f2e158653"},
+    {file = "grpcio-1.47.5-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:64401ee6d54b4d5869bcba4be3cae9f2e335c44a39ba1e29991ad22cfe2abacb"},
+    {file = "grpcio-1.47.5-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39a07eb5e7ec9277e5d124fb0e2d4f51ddbaadc2abdd27e8bbf1716dcf45e581"},
+    {file = "grpcio-1.47.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:874b138ca95a6375ae6f6a12c10a348827c9aa8fbd05d025b87b5e050ab55b46"},
+    {file = "grpcio-1.47.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:90539369afba42fc921cdda9d5f697a421f05a2e82ba58342ffbe88aa586019e"},
+    {file = "grpcio-1.47.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b18f970514bbc76547928e26d0cec06996ce3f947a3634b3adbe79d0e48e980"},
+    {file = "grpcio-1.47.5-cp310-cp310-win32.whl", hash = "sha256:44c52923be0c4a0f662de43644679c6356960c38c4edf44864c23b998693c7cc"},
+    {file = "grpcio-1.47.5-cp310-cp310-win_amd64.whl", hash = "sha256:07761f427551fced386db8c78701d6a167b2a682aa8df808303dd0a0d44bf6c9"},
+    {file = "grpcio-1.47.5-cp36-cp36m-linux_armv7l.whl", hash = "sha256:10eb026bf75568de06933366f0340d2b4b207425c74a5640aa1812b8b69e7d9d"},
+    {file = "grpcio-1.47.5-cp36-cp36m-macosx_10_10_universal2.whl", hash = "sha256:4f8e7fba6b1150a63aebd04d03be779de4ea4c4a8b28869e7a3c8f0b3ec59edc"},
+    {file = "grpcio-1.47.5-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:36d93b19c214bc654fc50ae65cce84b8f7698159191b9d3f21f9ad92ae7bc325"},
+    {file = "grpcio-1.47.5-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e59f916bf58528e55893743151c6bd9f0a393fddfe411a6fffd29a300e6acf2"},
+    {file = "grpcio-1.47.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18f8b2d316a3be464eb2a20afa7026a235a07a0094be879876611206d8026679"},
+    {file = "grpcio-1.47.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:0c3076957cd2aea34fe69384453315fd765948eb6cb73a12f332277308d04b76"},
+    {file = "grpcio-1.47.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:007f5ad07d2f3a4a422c1df589a0d25e918b96d8f6069cb6f0254386a5f09262"},
+    {file = "grpcio-1.47.5-cp36-cp36m-win32.whl", hash = "sha256:01ac149a5ca9512277b1d2fe85687099f3e442c6f9f924eae003a6700735e23e"},
+    {file = "grpcio-1.47.5-cp36-cp36m-win_amd64.whl", hash = "sha256:a32ccc88950f2be619157201161e70a5e5ed9e2427662bb2e60f1a8cea7d0db6"},
+    {file = "grpcio-1.47.5-cp37-cp37m-linux_armv7l.whl", hash = "sha256:ec71f15258e086acadb13ec06e4e4c54eb0f5455cd4c618997f847874d5ff9ea"},
+    {file = "grpcio-1.47.5-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:4bbf5a63497dbd5e44c4335cab153796a4274be17ca40ec971a7749c3f4fef6a"},
+    {file = "grpcio-1.47.5-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:11e1bc97e88232201256b718c63a8a1fd86ec6fca3a501293be5c5e423de9d56"},
+    {file = "grpcio-1.47.5-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e568d84fed80713d2fa3221552beee27ed8034f7eff52bb7871bf5ffe4d4ca78"},
+    {file = "grpcio-1.47.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb4c838de8e1e7194d3f9a679fd76cc44a1dbe81f18bd39ee233c72347d772bf"},
+    {file = "grpcio-1.47.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:a74c19baf2f8127b44b3f58e2a5801a17992dae9a20197b4a8fa26e2ea79742b"},
+    {file = "grpcio-1.47.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e369ed5ecff11ef85666cabbb5736495604e052c8dc2c03a2104f99dfd0a59e3"},
+    {file = "grpcio-1.47.5-cp37-cp37m-win32.whl", hash = "sha256:ccb741fab5117aea981d4ac341d2ce1e588f515f83091807d4e2bb388ed59edd"},
+    {file = "grpcio-1.47.5-cp37-cp37m-win_amd64.whl", hash = "sha256:af9d3b075dfcbc343d44b0e98725ba6d56dc0669e61905a4e71e8f4409cfefbd"},
+    {file = "grpcio-1.47.5-cp38-cp38-linux_armv7l.whl", hash = "sha256:cac6847a4b9a7e7a1f270a71fef1c17c2e8a6b411c0ca48080ce1e08d284aded"},
+    {file = "grpcio-1.47.5-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:54a3e17d155b6fb141e1fbb7c47d30556bec4c940b66ff4d9513536e2e214d4a"},
+    {file = "grpcio-1.47.5-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:d1873c0b84a0ffb129f75e7c8be45d2cae427baf0b090d15b9ff46c1841c3f53"},
+    {file = "grpcio-1.47.5-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e209df91cf8dfb335c2e26784702b0e12c20dc4de7b9b6d2cccd968146155f06"},
+    {file = "grpcio-1.47.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:350e2627684f93f8b59af9c76a03eeb4aa145ecc589569137d4518486f4f1727"},
+    {file = "grpcio-1.47.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:23754807314c5aa4c26eb1c50aaf506801a2f7825951100280d2c013b127436f"},
+    {file = "grpcio-1.47.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:503c3fa0045f3ef80aa1ad082eac6a888081da2e1cd793f281ed499831e4c498"},
+    {file = "grpcio-1.47.5-cp38-cp38-win32.whl", hash = "sha256:a4eecfbe994c88996461bd1459e43ea460952d4147f53e8c18e089764e6808f5"},
+    {file = "grpcio-1.47.5-cp38-cp38-win_amd64.whl", hash = "sha256:941927ae4d589a2fef5c22b9c47df9e5e613c737bd750bafc3a9547cc506017c"},
+    {file = "grpcio-1.47.5-cp39-cp39-linux_armv7l.whl", hash = "sha256:9891c77e69bd4109c25c1bea51d78fbc5ba2fcd9445bf99225bb8fb03d849913"},
+    {file = "grpcio-1.47.5-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:61e83778d85dbbbd7446451ec28b7261e9ebba489cc8c262dfe8fedc119f769b"},
+    {file = "grpcio-1.47.5-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:21ccfc0e989531cbdc93c54a7581ea5f7c46bf585016d9320b4be042f1e02374"},
+    {file = "grpcio-1.47.5-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bea35a0114a39827ffe59f73950d242f95d59a9ac2009ae8da7b065c06f0a57f"},
+    {file = "grpcio-1.47.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e75b9e52eeb9d1335aaeecf581cb3cea7fc4bafd7bd675c83f208a386a42a8"},
+    {file = "grpcio-1.47.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1fb86f95228827b55e860278d142326af4489c0f4220975780daff325fc87172"},
+    {file = "grpcio-1.47.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c9b83183525afe58dd9e7bb249f9e55df326e3c3834d09ea476c7a6bb12f73ee"},
+    {file = "grpcio-1.47.5-cp39-cp39-win32.whl", hash = "sha256:00bff7492875ab04ec5ed3d92550d8f8aa423151e187b79684c8a22c7a6f1670"},
+    {file = "grpcio-1.47.5-cp39-cp39-win_amd64.whl", hash = "sha256:2b32adae820cc0347e5e44efe91b661b436dbca73f25c5763cadb1cafd1dca10"},
+    {file = "grpcio-1.47.5.tar.gz", hash = "sha256:b62b8bea0c94b4603bb4c8332d8a814375120bea3c2dbeb71397213bde5ea832"},
 ]
 
 [package.dependencies]
 six = ">=1.5.2"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.47.0)"]
+protobuf = ["grpcio-tools (>=1.47.5)"]
 
 [[package]]
 name = "hexbytes"
@@ -2061,18 +2033,18 @@ files = [
 
 [[package]]
 name = "open-aea"
-version = "1.36.0"
+version = "1.37.0"
 description = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "open-aea-1.36.0.tar.gz", hash = "sha256:3f64b27d263f041f401980c303e55b726c301c5b9bed0a9542fe9233ad1b51cb"},
-    {file = "open_aea-1.36.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:e66f05b8d044576c3a38fe3924e8d50e69159dfe857c9831fec04a9038428430"},
-    {file = "open_aea-1.36.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:a2872fcfbf2862e621b680bb327b428073c7f724caeedc356d2e8b3dfaadee2a"},
-    {file = "open_aea-1.36.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:eb92a01202459fe20baa0b63bbd1ff1b4fbc939a7db246b26a26b8a9e60f4c89"},
-    {file = "open_aea-1.36.0-py3-none-win32.whl", hash = "sha256:9bfe58ae92f2375605300ed2906937754e3ad295c402b0190d4d776d6c6bdaeb"},
-    {file = "open_aea-1.36.0-py3-none-win_amd64.whl", hash = "sha256:28532b3d3fafcc641f6fc4a86e9a1e49d3304d4b11add5c1990ba72691db84a3"},
+    {file = "open-aea-1.37.0.tar.gz", hash = "sha256:9ad04e922466e4922e5b98034d42060774e0a41ee9df67dcd1b84203081b252d"},
+    {file = "open_aea-1.37.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:5e7404c8166f369c0418af8e1dcebe989503c8e247cdf370037a735f1d3752d7"},
+    {file = "open_aea-1.37.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:7b7431349bba5ba54340812a58738dd6ff9c24a76b9a708cba4421e09b32861d"},
+    {file = "open_aea-1.37.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:230a6f10468148a983f8274f3703da60614cb7560052b383e062fd447dd61091"},
+    {file = "open_aea-1.37.0-py3-none-win32.whl", hash = "sha256:e8e0b63026a930c5f4b96ec906a82f944d928daff6831849bb177841c29550e8"},
+    {file = "open_aea-1.37.0-py3-none-win_amd64.whl", hash = "sha256:6211446d61762d22afaf4af62d16de32d6837bcea7db484a47cb5debf775dca1"},
 ]
 
 [package.dependencies]
@@ -2100,14 +2072,14 @@ test-tools = ["click (==8.0.2)", "coverage (>=6.4.4,<8.0.0)", "jsonschema (>=4.1
 
 [[package]]
 name = "open-aea-cli-ipfs"
-version = "1.36.0"
+version = "1.37.0"
 description = "CLI extension for open AEA framework wrapping IPFS functionality."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "open-aea-cli-ipfs-1.36.0.tar.gz", hash = "sha256:92eacc760a95b9dce2877af7ed3404ca3f8d954f3de62005c2f9b887d32a0cd1"},
-    {file = "open_aea_cli_ipfs-1.36.0-py3-none-any.whl", hash = "sha256:ffe0a6b8bd5d6ca27c0acd988f4b4fa9a04f0a81eeff3d8beb3a0295f0a6eced"},
+    {file = "open-aea-cli-ipfs-1.37.0.tar.gz", hash = "sha256:9ac193d8a46ae3ea28debbbee28ec847d2d4ab66aae5d550b2da500a8096b751"},
+    {file = "open_aea_cli_ipfs-1.37.0-py3-none-any.whl", hash = "sha256:83375b3b0244044363980cfd67dad06de2619e2ed498aba107517795cd5a6b7a"},
 ]
 
 [package.dependencies]
@@ -2116,34 +2088,57 @@ open-aea = ">=1.0.0,<2.0.0"
 pytest = ">=7.0.0,<7.3.0"
 
 [[package]]
+name = "open-aea-cosmpy"
+version = "0.6.3"
+description = "A library for interacting with the cosmos networks"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "open_aea_cosmpy-0.6.3-py3-none-any.whl", hash = "sha256:5a2718b02bd9acf6257d69dacd048f4b81b8313c1f300f4b209ae20fd94626fa"},
+    {file = "open_aea_cosmpy-0.6.3.tar.gz", hash = "sha256:0d8997590a1fa1c936cf55106638ded7c3b74278d51129be436fbdf5078beb4b"},
+]
+
+[package.dependencies]
+bech32 = "*"
+bip-utils = "*"
+blspy = "*"
+ecdsa = "*"
+google-api-python-client = "*"
+grpcio = "1.47.5"
+jsonschema = ">=3.2.0,<5"
+protobuf = ">=3.19.4,<4"
+requests = "*"
+
+[[package]]
 name = "open-aea-ledger-cosmos"
-version = "1.36.0"
+version = "1.37.0"
 description = "Python package wrapping the public and private key cryptography and ledger api of Cosmos."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "open-aea-ledger-cosmos-1.36.0.tar.gz", hash = "sha256:6d32c90c69d20e519e0cb34c83bd4a0706c54c28631c8f18ec2a27bcdd278ea9"},
-    {file = "open_aea_ledger_cosmos-1.36.0-py3-none-any.whl", hash = "sha256:49dbeb3d5cedb8ec0baa63e7ab644f29ed2f148e679628f47b8f50570aed5e33"},
+    {file = "open-aea-ledger-cosmos-1.37.0.tar.gz", hash = "sha256:25107cfa58fc711a3c78ca465bbbedc9a3c34ad689a61afa22c2889fc7ffa955"},
+    {file = "open_aea_ledger_cosmos-1.37.0-py3-none-any.whl", hash = "sha256:c0ab0cf37820f57335fc181a75d89d72ed56b4eec3693036bf9c7672aefe114f"},
 ]
 
 [package.dependencies]
 bech32 = "1.2.0"
-cosmpy = "0.6.0"
 ecdsa = ">=0.15,<0.17.0"
 open-aea = ">=1.0.0,<2.0.0"
+open-aea-cosmpy = "0.6.3"
 pycryptodome = ">=3.10.1,<4.0.0"
 
 [[package]]
 name = "open-aea-ledger-ethereum"
-version = "1.36.0"
+version = "1.37.0"
 description = "Python package wrapping the public and private key cryptography and ledger api of Ethereum."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "open-aea-ledger-ethereum-1.36.0.tar.gz", hash = "sha256:ef450d6e81470689572bb9489aefdaa469b880e3ea84e661a027b5acf5896e85"},
-    {file = "open_aea_ledger_ethereum-1.36.0-py3-none-any.whl", hash = "sha256:6092194a208ed5270c9fd7625b13c6e68c13cb9bfa1140f8763bf41fb426e0ed"},
+    {file = "open-aea-ledger-ethereum-1.37.0.tar.gz", hash = "sha256:b8ae21219154e48a8f51df1dc44684815d039b305071fc37f05bfaf48138baa3"},
+    {file = "open_aea_ledger_ethereum-1.37.0-py3-none-any.whl", hash = "sha256:b6136627ce092f5f77544d48426d317b5032e3b1a58283768c7c71adad370585"},
 ]
 
 [package.dependencies]
@@ -2154,22 +2149,22 @@ web3 = "5.31.4"
 
 [[package]]
 name = "open-autonomy"
-version = "0.10.8"
+version = "0.10.9"
 description = "A framework for the creation of autonomous agent services."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "open-autonomy-0.10.8.tar.gz", hash = "sha256:4adb19f4b431fe6678579577f9172c5b3cd2ba5e0ddb4aab49e3ef144a0403ad"},
-    {file = "open_autonomy-0.10.8-py3-none-any.whl", hash = "sha256:323c9c1a83792965fda9a9c5ae17e0359179cea2aef25b8512da827730f9e032"},
+    {file = "open-autonomy-0.10.9.tar.gz", hash = "sha256:0c6ea349fbf2b739bb5a14a0ec60f0533460462c8853a0e686fdafd82bcf6a45"},
+    {file = "open_autonomy-0.10.9-py3-none-any.whl", hash = "sha256:269ef33637a328d0a0587fa9635a779c1806cddbf6eb886ec9bdd899ecd2517f"},
 ]
 
 [package.dependencies]
 click = "8.0.2"
 docker = "6.1.2"
 Flask = ">=2.0.2,<3.0.0"
-open-aea = {version = "1.36.0", extras = ["all"]}
-open-aea-cli-ipfs = "1.36.0"
+open-aea = {version = "1.37.0", extras = ["all"]}
+open-aea-cli-ipfs = "1.37.0"
 pandas = ">=1.3.4,<1.4"
 pytest = "7.2.1"
 python-dotenv = ">=0.14.0,<0.18.0"
@@ -2179,8 +2174,8 @@ watchdog = ">=2.1.6"
 werkzeug = "2.0.3"
 
 [package.extras]
-all = ["click (==8.0.2)", "open-aea-cli-ipfs (==1.36.0)", "python-dotenv (>=0.14.0,<0.18.0)", "texttable (==1.6.7)"]
-cli = ["click (==8.0.2)", "open-aea-cli-ipfs (==1.36.0)", "python-dotenv (>=0.14.0,<0.18.0)", "texttable (==1.6.7)"]
+all = ["click (==8.0.2)", "open-aea-cli-ipfs (==1.37.0)", "python-dotenv (>=0.14.0,<0.18.0)", "texttable (==1.6.7)"]
+cli = ["click (==8.0.2)", "open-aea-cli-ipfs (==1.37.0)", "python-dotenv (>=0.14.0,<0.18.0)", "texttable (==1.6.7)"]
 
 [[package]]
 name = "packaging"
@@ -3120,24 +3115,24 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.24.1"
+version = "20.24.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.24.1-py3-none-any.whl", hash = "sha256:01aacf8decd346cf9a865ae85c0cdc7f64c8caa07ff0d8b1dfc1733d10677442"},
-    {file = "virtualenv-20.24.1.tar.gz", hash = "sha256:2ef6a237c31629da6442b0bcaa3999748108c7166318d1f55cc9f8d7294e97bd"},
+    {file = "virtualenv-20.24.2-py3-none-any.whl", hash = "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff"},
+    {file = "virtualenv-20.24.2.tar.gz", hash = "sha256:fd8a78f46f6b99a67b7ec5cf73f92357891a7b3a40fd97637c27f854aae3b9e0"},
 ]
 
 [package.dependencies]
-distlib = ">=0.3.6,<1"
-filelock = ">=3.12,<4"
-platformdirs = ">=3.5.1,<4"
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<4"
 
 [package.extras]
 docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
-test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "watchdog"
@@ -3289,18 +3284,18 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "wheel"
-version = "0.40.0"
+version = "0.41.0"
 description = "A built-package format for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "wheel-0.40.0-py3-none-any.whl", hash = "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"},
-    {file = "wheel-0.40.0.tar.gz", hash = "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873"},
+    {file = "wheel-0.41.0-py3-none-any.whl", hash = "sha256:7e9be3bbd0078f6147d82ed9ed957e323e7708f57e134743d2edef3a7b7972a9"},
+    {file = "wheel-0.41.0.tar.gz", hash = "sha256:55a0f0a5a84869bce5ba775abfd9c462e3a6b1b7b7ec69d72c0b83d673a5114d"},
 ]
 
 [package.extras]
-test = ["pytest (>=6.0.0)"]
+test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
 name = "yarl"
@@ -3393,4 +3388,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fa598da376fae8dbf9e8be1b92b857240719a7000393e6006dde4645a05e47a4"
+content-hash = "60245b54522a3ea5475cccae87b691e53b09f687df41dfdba406afcc319e154b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,19 +26,19 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-open-aea = {version = "1.36.0", extras = ["cli"]}
-open-aea-ledger-ethereum = "1.36.0"
-open-aea-cli-ipfs = "1.36.0"
+open-aea = {version = "1.37.0", extras = ["cli"]}
+open-aea-ledger-ethereum = "1.37.0"
+open-aea-cli-ipfs = "1.37.0"
 websocket-client = ">=0.32.0,<1"
 gql = ">=3.4.1"
 asn1crypto = ">=1.4.0,<1.5.0"
-open-aea-ledger-cosmos = "1.36.0"
+open-aea-ledger-cosmos = "1.37.0"
 
 [tool.poetry.scripts]
 mechx = "mech_client.cli:cli"
 
 [tool.poetry.group.dev.dependencies]
-open-autonomy = "==0.10.8"
+open-autonomy = "==0.10.9"
 tomte = {extras = ["tox"], version = "==0.2.13"}
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = True
 [base-deps]
 deps =
     tomte[tests]==0.2.13
-    open-autonomy==0.10.8
+    open-autonomy==0.10.9
 
 [testenv:bandit]
 skipsdist = True


### PR DESCRIPTION
This PR bumps the mech-client to latest framework versions.