### PR TITLE
Fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-versions }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing


### PR DESCRIPTION
The Python version was being ignored because of the python-version*s* typo:

- https://github.com/valory-xyz/mech-client/blob/03cfe06d591e84b39b6bf9f8cd0c0a44ec8ebedd/.github/workflows/release.yml#L13
- https://github.com/valory-xyz/mech-client/blob/03cfe06d591e84b39b6bf9f8cd0c0a44ec8ebedd/.github/workflows/release.yml#L18