### PR TITLE
docs: add Native Payment and NVM Subscriptions to chain support matrices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -893,18 +893,20 @@ validated_safe = validate_ethereum_address(safe, "Safe address")
 
 ## Chain Support Matrix
 
-| Chain | Chain ID | Marketplace | Agent Mode | OLAS Token | USDC Token | Subgraph | Legacy Mechs |
-|-------|----------|-------------|------------|------------|------------|----------|--------------|
-| Gnosis | 100 | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| Base | 8453 | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Polygon | 137 | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Optimism | 10 | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Arbitrum | 42161 | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Celo | 42220 | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Chain | Chain ID | Marketplace | Agent Mode | Native Payment | NVM Subscriptions | OLAS Token | USDC Token | Subgraph | Legacy Mechs |
+|-------|----------|-------------|------------|----------------|-------------------|------------|------------|----------|--------------|
+| Gnosis | 100 | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Base | 8453 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Polygon | 137 | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Optimism | 10 | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Arbitrum | 42161 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Celo | 42220 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 **Feature Definitions:**
 - **Marketplace**: Chain has `mech_marketplace_contract` deployed (non-zero address in `mechs.json`)
 - **Agent Mode**: Supports `setup-agent-mode` command and Safe-based agent operations (all marketplace chains: Gnosis, Base, Polygon, Optimism)
+- **Native Payment**: Supports `deposit-native` command for prepaid native token deposits (Gnosis, Base, Polygon, Optimism)
+- **NVM Subscriptions**: Supports `purchase-nvm-subscription` command for Nevermined subscription-based payments (Gnosis, Base)
 - **OLAS/USDC Token**: Payment token addresses configured in `marketplace_interact.py`
 - **Subgraph**: Built-in subgraph URL in `mechs.json` (currently all chains have empty `subgraph_url`; must be set via `MECHX_SUBGRAPH_URL` for `fetch-mm-mechs-info`)
 - **Legacy Mechs**: All chains support legacy mech interactions via `agent_id`
@@ -913,7 +915,9 @@ validated_safe = validate_ethereum_address(safe, "Safe address")
 - `fetch-mm-mechs-info`: Requires marketplace + `MECHX_SUBGRAPH_URL` environment variable
 - `interact` (marketplace): Requires marketplace contract
 - `interact` (legacy): Requires agent registry only
-- `deposit-native/deposit-token`: Requires marketplace + token addresses in config
+- `deposit-native`: Requires marketplace + native payment support (Gnosis, Base, Polygon, Optimism)
+- `deposit-token`: Requires marketplace + token addresses in config (Gnosis, Base, Polygon, Optimism)
+- `purchase-nvm-subscription`: Requires marketplace + NVM subscription support (Gnosis, Base)
 - `setup-agent-mode`: All marketplace chains (Gnosis, Base, Polygon, Optimism)
 
 ## Important Notes

--- a/README.md
+++ b/README.md
@@ -81,18 +81,21 @@ Learn more about mech marketplace [here](https://olas.network/mech-marketplace)
 
 The Mech Client supports multiple chains with different feature availability:
 
-| Chain | Legacy Mechs | Marketplace | Agent Mode | OLAS Payments | USDC Payments |
-|-------|-------------|-------------|------------|---------------|---------------|
-| Gnosis | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Base | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Polygon | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Optimism | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Arbitrum | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Celo | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Chain | Legacy Mechs | Marketplace | Agent Mode | Native Payment | NVM Subscriptions | OLAS Payments | USDC Payments |
+|-------|-------------|-------------|------------|----------------|-------------------|---------------|---------------|
+| Gnosis | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Base | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Polygon | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Optimism | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Arbitrum | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Celo | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 **Notes:**
-- **Marketplace**: Chains with marketplace contracts deployed. Required for `interact` with marketplace mechs, `deposit-*`, and `fetch-mm-mechs-info` commands.
+- **Marketplace**: Chains with marketplace contracts deployed. Required for `interact` with marketplace mechs and `fetch-mm-mechs-info` commands.
 - **Agent Mode**: Chains that support on-chain agent registration via `setup-agent-mode`.
+- **Native Payment**: Chains that support `deposit-native` command for prepaid native token deposits (Gnosis, Base, Polygon, Optimism).
+- **NVM Subscriptions**: Chains that support `purchase-nvm-subscription` command for Nevermined subscription-based payments (Gnosis, Base).
+- **OLAS/USDC Payments**: Chains that support `deposit-token` command with OLAS or USDC tokens.
 - **Legacy Mechs**: All chains support direct interaction with legacy mech agents via `interact --agent_id`.
 - **Subgraph**: The `fetch-mm-mechs-info` command requires setting `MECHX_SUBGRAPH_URL` environment variable for any chain.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,20 +43,22 @@ pip install mech-client
 
 The Mech Client supports multiple blockchain networks with different feature availability:
 
-| Chain | Legacy Mechs | Marketplace | Agent Mode | OLAS Payments | USDC Payments |
-|-------|-------------|-------------|------------|---------------|---------------|
-| Gnosis | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Base | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Polygon | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Optimism | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Arbitrum | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Celo | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Chain | Legacy Mechs | Marketplace | Agent Mode | Native Payment | NVM Subscriptions | OLAS Payments | USDC Payments |
+|-------|-------------|-------------|------------|----------------|-------------------|---------------|---------------|
+| Gnosis | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Base | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Polygon | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Optimism | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Arbitrum | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Celo | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 **Key:**
-- **Marketplace**: Chains with marketplace contracts. Required for marketplace mech interactions and deposit commands.
+- **Marketplace**: Chains with marketplace contracts. Required for marketplace mech interactions.
 - **Agent Mode**: Chains supporting on-chain agent registration (all marketplace chains: Gnosis, Base, Polygon, Optimism).
+- **Native Payment**: Chains supporting `deposit-native` command for prepaid native token deposits (Gnosis, Base, Polygon, Optimism).
+- **NVM Subscriptions**: Chains supporting `purchase-nvm-subscription` command for Nevermined subscription-based payments (Gnosis, Base).
+- **OLAS/USDC Payments**: Chains supporting `deposit-token` command with OLAS or USDC tokens.
 - **Legacy Mechs**: All chains support direct interaction with legacy mech agents.
-- **OLAS/USDC Payments**: Token payment support varies by chain deployment.
 
 **Important Notes:**
 - The `fetch-mm-mechs-info` command works on all marketplace chains (Gnosis, Base, Polygon, Optimism) but requires setting the `MECHX_SUBGRAPH_URL` environment variable.


### PR DESCRIPTION
Expands chain support documentation across all files to explicitly list native payment deposits and NVM subscription support per chain, providing clearer guidance on payment method availability.