### PR TITLE
fix: remove automatic wei conversion from deposit amount inputs

### DIFF
--- a/mech_client/deposits.py
+++ b/mech_client/deposits.py
@@ -350,7 +350,7 @@ def deposit_native_main(  # pylint: disable=too-many-arguments,too-many-locals
     print("This script will assist you in depositing native balance for mech requests.")
     print()
 
-    amount_to_deposit = int(float(amount) * 10**18)
+    amount_to_deposit = int(amount)
     private_key_path = private_key_path or PRIVATE_KEY_FILE_PATH
 
     mech_config = get_mech_config(chain_config)
@@ -425,7 +425,7 @@ def deposit_token_main(  # pylint: disable=too-many-arguments,too-many-locals,to
     print("This script will assist you in depositing token balance for mech requests.")
     print()
 
-    amount_to_deposit = int(float(amount) * 10**18)
+    amount_to_deposit = int(amount)
     private_key_path = private_key_path or PRIVATE_KEY_FILE_PATH
 
     mech_config = get_mech_config(chain_config)


### PR DESCRIPTION
Summary                                               
                                                                                                                  
  - Fix deposit amount double-conversion bug in deposit_native_main and deposit_token_main that corrupted the     
  amount passed by the CLI                                                                                        
  - The CLI already validates the amount as a positive integer in wei/smallest token unit, but deposits.py was    
  re-converting it via int(float(amount) * 10**18), inflating the value by 10^18 and introducing floating-point   
  precision loss (e.g., 10000000000000000 became 9999999999999999455752309870428160)
