### PR TITLE
chore: fix linter configurations for new CLI structure

### DIFF
--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -5,10 +5,18 @@ verify_tools # unused function
 get_native_balance_tracker_contract # unused function (mech_client/marketplace_interact.py:1149) - used by deposits.py
 get_token_balance_tracker_contract # used by deposits.py
 get_token_contract # used by deposits.py
-ACN_PROTOCOL_PACKAGE # unused variable (mech_client/helpers/__init__.py:25) - ejected from Open AEA packages
-P2P_CLIENT_PACKAGE # unused variable (mech_client/helpers/__init__.py:28) - ejected from Open AEA packages
-ACN_DATA_SHARE_PROTOCOL_PACKAGE # unused variable (mech_client/helpers/__init__.py:35) - ejected from Open AEA packages
 get_abi # unused function (mech_client/interact.py:154) - kept for potential future use
+
+# CLI command functions (used via Click decorators)
+request # CLI command function
+mech_list # CLI command function
+tool_list # CLI command function
+tool_describe # CLI command function
+tool_schema # CLI command function
+subscription_purchase # CLI command function
+ipfs_upload # CLI command function
+ipfs_upload_prompt # CLI command function
+ipfs_to_png # CLI command function
 
 # Existing entries...
 send_marketplace_request_nonblocking  # used in tests/locustfile.py

--- a/tox.ini
+++ b/tox.ini
@@ -205,7 +205,7 @@ ignore_missing_imports=True
 [darglint]
 docstring_style=sphinx
 strictness=short
-ignore_regex=async_act|.*nvm_subscription.*
+ignore_regex=async_act|.*nvm_subscription.*|^cli$|^setup$|request|mech_list|tool_list|tool_describe|tool_schema|deposit_native|deposit_token|subscription_purchase|ipfs_upload|ipfs_upload_prompt|ipfs_to_png
 ignore=DAR401
 
 


### PR DESCRIPTION
Updated linter configurations to work with the restructured CLI:
- Added new CLI command functions to vulture whitelist (Click decorators make them appear unused)
- Extended darglint ignore_regex to skip CLI command functions (parameters documented via Click decorators)
- Removed obsolete helpers directory references from whitelist

All linters now passing: black, isort, flake8, mypy, pylint, bandit, darglint, vulture.