### PR TITLE
fix: add --token-type option to deposit token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,14 @@ payment model of the Mech. For a fixed price Mech receiving payments in native t
 mechx deposit native --chain-config <chain_config> <amount>
 ```
 
-For a fixed price Mech receiving payments in OLAS, use the following (the amount is in ether):
+For a fixed price Mech receiving payments in OLAS or USDC tokens, use the following:
 
 ```bash
-mechx deposit token --chain-config <chain_config> <amount>
+# Deposit OLAS tokens (amount in wei, 18 decimals)
+mechx deposit token --chain-config <chain_config> --token-type olas <amount>
+
+# Deposit USDC tokens (amount in smallest unit, 6 decimals)
+mechx deposit token --chain-config <chain_config> --token-type usdc <amount>
 ```
 
 For a Mech using Nevermined subscriptions, to make requests, it is necessary to buy a subscription. To do that you can use the following command:

--- a/mech_client/cli/commands/deposit_cmd.py
+++ b/mech_client/cli/commands/deposit_cmd.py
@@ -213,6 +213,12 @@ def deposit_native(
     help="Chain configuration name (gnosis, base, polygon, optimism).",
 )
 @click.option(
+    "--token-type",
+    type=click.Choice(["olas", "usdc"], case_sensitive=False),
+    default="olas",
+    help="Token type to deposit (olas or usdc). Default: olas.",
+)
+@click.option(
     "--key",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help="Path to private key file (client mode only).",
@@ -223,6 +229,7 @@ def deposit_token(
     ctx: click.Context,
     amount_to_deposit: str,
     chain_config: str,
+    token_type: str,
     key: Optional[str] = None,
 ) -> None:
     """Deposit ERC20 tokens into prepaid balance.
@@ -231,8 +238,12 @@ def deposit_token(
     marketplace. Amount must be specified in the token's smallest unit
     (e.g., 18 decimals for OLAS, 6 decimals for USDC).
 
-    Example: mechx deposit token 1000000000000000000 --chain-config gnosis
-    (deposits 1.0 OLAS)
+    Examples:
+        mechx deposit token 1000000000000000000 --chain-config gnosis --token-type olas
+        (deposits 1.0 OLAS)
+
+        mechx deposit token 1000000 --chain-config base --token-type usdc
+        (deposits 1.0 USDC)
     """
     try:
         # Validate chain config
@@ -309,10 +320,10 @@ def deposit_token(
             ethereum_client=ethereum_client,
         )
 
-        # Execute deposit (defaulting to OLAS token for now)
+        # Execute deposit
         amount_int = int(amount_to_deposit)
-        click.echo(f"\nDepositing {amount_int} of OLAS tokens...")
-        tx_hash = service.deposit_token(amount_int, token_type="olas")  # nosec B106
+        click.echo(f"\nDepositing {amount_int} of {token_type.upper()} tokens...")
+        tx_hash = service.deposit_token(amount_int, token_type=token_type.lower())
         click.echo(f"\n✓ Deposit transaction: {tx_hash}")
 
     except ContractLogicError as e:


### PR DESCRIPTION
The deposit token command was hardcoded to only deposit OLAS tokens, but the system supports both OLAS and USDC deposits. Add a --token-type option to allow users to specify which token to deposit.

Changes:
- Add --token-type option with choices [olas, usdc]
- Default to 'olas' for backward compatibility
- Update command to use the token_type parameter
- Update docstring with examples for both OLAS and USDC
- Update README.md to show --token-type usage

Usage:
  mechx deposit token 1000000000000000000 --chain-config gnosis --token-type olas mechx deposit token 1000000 --chain-config base --token-type usdc