### PR TITLE
fix: correct polling cycle sleep behavior in marketplace delivery wat…

### DIFF
--- a/mech_client/domain/delivery/onchain_watcher.py
+++ b/mech_client/domain/delivery/onchain_watcher.py
@@ -113,18 +113,20 @@ class OnchainDeliveryWatcher(DeliveryWatcher):
                 if delivery_mech != ADDRESS_ZERO:
                     request_ids_data[request_id] = delivery_mech
 
-                await asyncio.sleep(WAIT_SLEEP)
-
-                elapsed_time = time.time() - start_time
-                if elapsed_time >= self.timeout:
-                    print(
-                        "Timeout reached while waiting for marketplace delivery. "
-                        "Returning partial data."
-                    )
-                    return request_ids_data
-
             # All requests delivered
             if len(request_ids_data) == len(request_ids):
+                return request_ids_data
+
+            # Sleep once per polling cycle, not per request ID
+            await asyncio.sleep(WAIT_SLEEP)
+
+            # Check timeout once per polling cycle
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= self.timeout:
+                print(
+                    "Timeout reached while waiting for marketplace delivery. "
+                    "Returning partial data."
+                )
                 return request_ids_data
 
     async def _fetch_data_urls_from_mechs(


### PR DESCRIPTION
…cher

Move sleep and timeout check outside the request ID loop to sleep once per polling cycle instead of once per request ID. Previously with 3 request IDs, it would sleep 9 seconds per cycle instead of 3 seconds.

Changes:
- Move await asyncio.sleep(WAIT_SLEEP) outside for request_id loop
- Move timeout check outside for request_id loop
- Add clarifying comments for polling cycle behavior

This matches the behavior in watch_for_data_urls() which correctly sleeps once per cycle.