### PR TITLE
fix: update test to match current subgraph query implementation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,27 @@
+[pytest]
+# Test configuration
+addopts =
+    -v
+    --tb=short
+    --strict-markers
+
+# Test discovery patterns
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Ignore patterns
+testpaths = tests
+norecursedirs =
+    .tox
+    .git
+    .eggs
+    dist
+    build
+    packages
+    stress_tests
+    .venv
+
+# Markers
+markers =
+    anyio: marks tests as async tests using anyio

--- a/tests/unit/infrastructure/test_subgraph_client.py
+++ b/tests/unit/infrastructure/test_subgraph_client.py
@@ -193,7 +193,7 @@ class TestSubgraphClientQueryMechs:
         # Verify query was constructed with default parameters
         call_args = mock_gql.call_args[1]
         query_str = call_args["request_string"]
-        assert "orderBy: service__totalDeliveries" in query_str
+        assert "orderBy: totalDeliveriesTransactions" in query_str
         assert "orderDirection: desc" in query_str
 
         # Verify result


### PR DESCRIPTION
The test was expecting the old field name 'service__totalDeliveries' but the implementation uses 'totalDeliveriesTransactions' as the default ordering field in SubgraphClient.query_mechs(). Updated test assertion to match actual behavior. Also added pytest.ini configuration file for test discovery and markers.