### PR TITLE
fix: enable token approvals through Safe multisig in agent mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,9 +331,7 @@ Critical bugs fixed in v0.17.1:
 3. **Polling Cycle Sleep** (`domain/delivery/onchain_watcher.py`): Sleep inside loop instead of outside ✅ Fixed
 4. **IPFS Pinning** (`infrastructure/ipfs/metadata.py`): Unnecessary pinning for offchain requests ✅ Fixed
 5. **Agent Mode RPC Configuration** (`infrastructure/config/chain_config.py`): Commands didn't read RPC from stored operate config ✅ Fixed (v0.18.1)
-
-Known issues:
-6. **Token Approval Agent Mode** (`domain/payment/token.py`): Only implements client mode path 📋 Documented in `docs/TOKEN_APPROVAL_AGENT_MODE_ISSUE.md`
+6. **Token Approval Agent Mode** (`domain/payment/token.py`): Token approvals didn't go through Safe in agent mode ✅ Fixed (v0.18.1)
 
 ## Release Workflow
 

--- a/mech_client/domain/payment/base.py
+++ b/mech_client/domain/payment/base.py
@@ -20,11 +20,15 @@
 """Base payment strategy interface."""
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 
 from aea_ledger_ethereum import EthereumApi
 
 from mech_client.infrastructure.config import PaymentType
+
+
+if TYPE_CHECKING:
+    from mech_client.domain.execution.base import TransactionExecutor
 
 
 class PaymentStrategy(ABC):
@@ -66,11 +70,12 @@ class PaymentStrategy(ABC):
         """
 
     @abstractmethod
-    def approve_if_needed(
+    def approve_if_needed(  # pylint: disable=too-many-arguments
         self,
         payer_address: str,
         spender_address: str,
         amount: int,
+        executor: Optional["TransactionExecutor"] = None,
         private_key: Optional[str] = None,
     ) -> Optional[str]:
         """
@@ -81,7 +86,8 @@ class PaymentStrategy(ABC):
         :param payer_address: Address of the payer
         :param spender_address: Address allowed to spend tokens
         :param amount: Amount to approve (in wei/smallest unit)
-        :param private_key: Private key for signing (client mode)
+        :param executor: Transaction executor (handles both agent and client mode)
+        :param private_key: Private key for signing (client mode without executor)
         :return: Transaction hash if approval was sent, None otherwise
         """
 

--- a/mech_client/domain/payment/native.py
+++ b/mech_client/domain/payment/native.py
@@ -19,12 +19,16 @@
 
 """Native token payment strategy."""
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from mech_client.domain.payment.base import PaymentStrategy
 from mech_client.infrastructure.blockchain.abi_loader import get_abi
 from mech_client.infrastructure.blockchain.contracts import get_contract
 from mech_client.infrastructure.config import CHAIN_TO_NATIVE_BALANCE_TRACKER
+
+
+if TYPE_CHECKING:
+    from mech_client.domain.execution.base import TransactionExecutor
 
 
 class NativePaymentStrategy(PaymentStrategy):
@@ -49,11 +53,12 @@ class NativePaymentStrategy(PaymentStrategy):
         balance = self.ledger_api.get_balance(payer_address)
         return balance >= amount
 
-    def approve_if_needed(
+    def approve_if_needed(  # pylint: disable=too-many-arguments
         self,
         payer_address: str,
         spender_address: str,
         amount: int,
+        executor: Optional["TransactionExecutor"] = None,
         private_key: Optional[str] = None,
     ) -> Optional[str]:
         """
@@ -62,6 +67,7 @@ class NativePaymentStrategy(PaymentStrategy):
         :param payer_address: Address of the payer
         :param spender_address: Address allowed to spend tokens (ignored)
         :param amount: Amount to approve (ignored)
+        :param executor: Transaction executor (ignored)
         :param private_key: Private key for signing (ignored)
         :return: None (no approval transaction)
         """

--- a/mech_client/domain/payment/nvm.py
+++ b/mech_client/domain/payment/nvm.py
@@ -19,7 +19,7 @@
 
 """Nevermined (NVM) subscription payment strategy."""
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from mech_client.domain.payment.base import PaymentStrategy
 from mech_client.infrastructure.blockchain.abi_loader import get_abi
@@ -29,6 +29,10 @@ from mech_client.infrastructure.config import (
     CHAIN_TO_TOKEN_BALANCE_TRACKER_USDC,
     PaymentType,
 )
+
+
+if TYPE_CHECKING:
+    from mech_client.domain.execution.base import TransactionExecutor
 
 
 class NVMPaymentStrategy(PaymentStrategy):
@@ -59,11 +63,12 @@ class NVMPaymentStrategy(PaymentStrategy):
         )
         return subscription_balance > 0
 
-    def approve_if_needed(
+    def approve_if_needed(  # pylint: disable=too-many-arguments
         self,
         payer_address: str,
         spender_address: str,
         amount: int,
+        executor: Optional["TransactionExecutor"] = None,
         private_key: Optional[str] = None,
     ) -> Optional[str]:
         """
@@ -74,6 +79,7 @@ class NVMPaymentStrategy(PaymentStrategy):
         :param payer_address: Address of the payer
         :param spender_address: Address allowed to spend (ignored)
         :param amount: Amount to approve (ignored)
+        :param executor: Transaction executor (ignored)
         :param private_key: Private key for signing (ignored)
         :return: None (no approval transaction)
         """

--- a/mech_client/services/deposit_service.py
+++ b/mech_client/services/deposit_service.py
@@ -160,6 +160,7 @@ class DepositService(
             payer_address=sender,
             spender_address=balance_tracker_address,
             amount=amount,
+            executor=self.executor,
             private_key=self.private_key,
         )
         if approve_tx:

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -182,6 +182,7 @@ class MarketplaceService(
                 payer_address=sender,
                 spender_address=balance_tracker,
                 amount=price,
+                executor=self.executor,
                 private_key=self.private_key,
             )
 


### PR DESCRIPTION
Previously, token approvals went directly from EOA instead of through Safe multisig in agent mode, causing "insufficient allowance" errors when the Safe tried to transfer tokens. This implements the executor pattern for approvals, allowing both agent mode (Safe) and client mode (EOA) to work correctly.

Changes:
- Add executor parameter to PaymentStrategy.approve_if_needed() signature
- Implement executor-based approval in TokenPaymentStrategy
- Update MarketplaceService and DepositService to pass executor
- Add comprehensive tests for both agent and client modes
- Maintain backward compatibility with fallback to direct signing