### PR TITLE
ci: add "All checks passed" aggregate gate job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -127,3 +127,13 @@ jobs:
         run: |
           echo Building distribution
           make dist
+
+  all-checks-passed:
+    name: All checks passed
+    if: always()
+    needs: [lock_check, linter_checks, test, build-pip-packages]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds an `all-checks-passed` meta job that runs after `lock_check`, `linter_checks`, `test`, and `build-pip-packages` and fails if any dependency failed or was cancelled.
- Once merged, branch protection on `main` will be flipped to require this single context (`All checks passed`) as the required status check, with `strict: true`.
- When adding/removing mandatory jobs in the future, update this job's `needs:` list — branch protection no longer needs to be edited.

## Test plan
- [ ] Verify the new job appears in this PR's checks and passes green when all `needs:` succeed.
- [ ] Verify the meta job is marked failed if any dependency fails (e.g., by observing a failing build).
- [ ] After merge, confirm the required status check `All checks passed` is enforced on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)