### PR TITLE
chore: bump open-aea-helpers to 0.21.19 + add check-third-party-hashes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,6 +68,8 @@ jobs:
       run: tox -e spell-check
     - name: License compatibility check
       run: tox -e liccheck
+    - name: Check third-party package hashes match upstream
+      run: tox -e check-third-party-hashes
 
   test:
     name: Run tests

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,12 +1,12 @@
 {
     "dev": {
-        "agent/valory/mech_client/0.1.0": "bafybeih7krxzhusq7ukvootbjpw5jpcdoixx6h63rezm4euwzsshrgrd4i",
-        "service/valory/mech_client/0.1.0": "bafybeibcnl6qvh5gvvrr6odq2sriyswyfdcyhh36nttajqvi3pibtnkl2y"
+        "agent/valory/mech_client/0.1.0": "bafybeiaudemcmceh4iukdhezxxhdypu2hwcrvrkiwl5zvhn34le2ucmziu",
+        "service/valory/mech_client/0.1.0": "bafybeihlke2upscxnrkq2gae4dsxzzncwpdqxhfawvw3zn6sesgjmwcft4"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
-        "connection/valory/abci/0.1.0": "bafybeihgtguy5ljj2rwgwoxeor5d565alwfggnuevss7malhzdats6nfqi",
-        "skill/valory/abstract_abci/0.1.0": "bafybeif4jcv22xrmkwiaecyyli7iknmdhtkg6dmzqmwpqekmvxyr7ba3xy"
+        "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
+        "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54"
     }
 }

--- a/packages/valory/agents/mech_client/aea-config.yaml
+++ b/packages/valory/agents/mech_client/aea-config.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeihsqhvkxixnofpz4bcwqdgydgqxcdlliikszucwvfquooygqxkle4
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeihgtguy5ljj2rwgwoxeor5d565alwfggnuevss7malhzdats6nfqi
+- valory/abci:0.1.0:bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu
 contracts: []
 protocols:
 - open_aea/signing:1.0.0:bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye
 - valory/abci:0.1.0:bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte
 skills:
-- valory/abstract_abci:0.1.0:bafybeif4jcv22xrmkwiaecyyli7iknmdhtkg6dmzqmwpqekmvxyr7ba3xy
+- valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/mech_client/service.yaml
+++ b/packages/valory/services/mech_client/service.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeibgcfkkosavrzc5oubkvrmq467dmpns2h54iwnlfaxlrbam5f6z5y
 fingerprint_ignore_patterns: []
 number_of_agents: 1
-agent: valory/mech_client:0.1.0:bafybeih7krxzhusq7ukvootbjpw5jpcdoixx6h63rezm4euwzsshrgrd4i
+agent: valory/mech_client:0.1.0:bafybeiaudemcmceh4iukdhezxxhdypu2hwcrvrkiwl5zvhn34le2ucmziu
 deployment: {}
 dependencies: {}
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,11 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     "gql>=3.4.1",
-    "asn1crypto>=1.4.0,<1.5.0",
-    "websocket-client>=0.32.0,<1",
     "tabulate>=0.9.0,<0.10",
     "setuptools>=78.1.1,<82",
     "olas-operate-middleware==0.15.2",
     "safe-eth-py>=7.18.0,<8",
     "click==8.1.8",
-    "jsonschema>=4.20.0,<4.24.0",
-    "pydantic>=2.12.0",
     "open-aea-helpers==0.21.19",
     "pip>=24.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,15 @@ requires-python = ">=3.10,<3.15"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
+    # OA / open-aea / plugins — pinned exactly (framework contract).
+    "open-aea-helpers==0.21.19",
+    # Framework/lib deps — ranges.
     "gql>=3.4.1",
     "tabulate>=0.9.0,<0.10",
     "setuptools>=78.1.1,<82",
-    "olas-operate-middleware==0.15.2",
+    "olas-operate-middleware>=0.15.2,<0.16",
     "safe-eth-py>=7.18.0,<8",
-    "click==8.1.8",
-    "open-aea-helpers==0.21.19",
+    "click<9,>=8.1",
     "pip>=24.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "click==8.1.8",
     "jsonschema>=4.20.0,<4.24.0",
     "pydantic>=2.12.0",
-    "open-aea-helpers==0.21.18",
+    "open-aea-helpers==0.21.19",
     "pip>=24.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -257,9 +257,20 @@ skipsdist = True
 skip_install = True
 deps =
     pip
-    open-autonomy[all]==0.21.18
+    open-autonomy[all]==0.21.19
 commands =
     autonomy packages lock --check
+
+[testenv:check-third-party-hashes]
+skipsdist = True
+skip_install = True
+deps =
+    open-aea==2.2.1
+    open-aea-ci-helpers==2.2.1
+commands =
+    aea-ci check-third-party-hashes \
+        --upstream valory-xyz/open-autonomy@0.21.19 \
+        --upstream valory-xyz/open-aea@2.2.1
 
 [Authorized Packages]
 ; open-autonomy wheel metadata reports "Other/Proprietary" due to the

--- a/uv.lock
+++ b/uv.lock
@@ -1841,9 +1841,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = "==8.1.8" },
+    { name = "click", specifier = ">=8.1,<9" },
     { name = "gql", specifier = ">=3.4.1" },
-    { name = "olas-operate-middleware", specifier = "==0.15.2" },
+    { name = "olas-operate-middleware", specifier = ">=0.15.2,<0.16" },
     { name = "open-aea-helpers", specifier = "==0.21.19" },
     { name = "pip", specifier = ">=24.0" },
     { name = "safe-eth-py", specifier = ">=7.18.0,<8" },

--- a/uv.lock
+++ b/uv.lock
@@ -232,15 +232,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asn1crypto"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b4/42f0e52ac2184a8abb31f0a6f98111ceee1aac0b473cee063882436e0e09/asn1crypto-1.4.0.tar.gz", hash = "sha256:f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c", size = 118733, upload-time = "2020-07-28T14:18:19.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/a8/56be92dcd4a5bf1998705a9b4028249fe7c9a035b955fe93b6a3e5b829f8/asn1crypto-1.4.0-py2.py3-none-any.whl", hash = "sha256:4bcdf33c861c7d40bdcd74d8e4dd7661aac320fcdf40b9a3f95b4ee12fde2fa8", size = 104031, upload-time = "2020-07-28T14:18:17.302Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1829,18 +1820,14 @@ name = "mech-client"
 version = "0.20.1"
 source = { editable = "." }
 dependencies = [
-    { name = "asn1crypto" },
     { name = "click" },
     { name = "gql" },
-    { name = "jsonschema" },
     { name = "olas-operate-middleware" },
     { name = "open-aea-helpers" },
     { name = "pip" },
-    { name = "pydantic" },
     { name = "safe-eth-py" },
     { name = "setuptools" },
     { name = "tabulate" },
-    { name = "websocket-client" },
 ]
 
 [package.dev-dependencies]
@@ -1854,18 +1841,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asn1crypto", specifier = ">=1.4.0,<1.5.0" },
     { name = "click", specifier = "==8.1.8" },
     { name = "gql", specifier = ">=3.4.1" },
-    { name = "jsonschema", specifier = ">=4.20.0,<4.24.0" },
     { name = "olas-operate-middleware", specifier = "==0.15.2" },
     { name = "open-aea-helpers", specifier = "==0.21.19" },
     { name = "pip", specifier = ">=24.0" },
-    { name = "pydantic", specifier = ">=2.12.0" },
     { name = "safe-eth-py", specifier = ">=7.18.0,<8" },
     { name = "setuptools", specifier = ">=78.1.1,<82" },
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
-    { name = "websocket-client", specifier = ">=0.32.0,<1" },
 ]
 
 [package.metadata.requires-dev]
@@ -3761,18 +3744,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/84/1516ee335e89e4d7d0837895d21091244ee3189d1ffe76fa435d2bd15f4e/web3-7.15.0.tar.gz", hash = "sha256:2a2bcbab8fcf120c2256ddbdc88fcc80a47c100ad758659a980e9fab66609171", size = 2211838, upload-time = "2026-04-02T18:20:40.355Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/f0/ef9b82557b22b1cdb95ec7863d1d9897ed3b9e096a1af5e046fb892efdc0/web3-7.15.0-py3-none-any.whl", hash = "sha256:bbeba510aaa4eb3c99662d911db9d2a648ab40f608cf0269065f7db1d1d0b0c0", size = 1373052, upload-time = "2026-04-02T18:20:36.757Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "0.59.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/bf/c706b56243f1641159ff211b51d3341024e1cdf63defc2b74595b6319039/websocket-client-0.59.0.tar.gz", hash = "sha256:d376bd60eace9d437ab6d7ee16f4ab4e821c9dae591e1b783c58ebd8aaf80c5c", size = 57897, upload-time = "2021-05-05T01:43:07.811Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/0c/d52a2a63512a613817846d430d16a8fbe5ea56dd889e89c68facf6b91cb6/websocket_client-0.59.0-py2.py3-none-any.whl", hash = "sha256:2e50d26ca593f70aba7b13a489435ef88b8fc3b5c5643c1ce8808ff9b40f0b32", size = 67216, upload-time = "2021-05-05T01:43:04.863Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1859,7 +1859,7 @@ requires-dist = [
     { name = "gql", specifier = ">=3.4.1" },
     { name = "jsonschema", specifier = ">=4.20.0,<4.24.0" },
     { name = "olas-operate-middleware", specifier = "==0.15.2" },
-    { name = "open-aea-helpers", specifier = "==0.21.18" },
+    { name = "open-aea-helpers", specifier = "==0.21.19" },
     { name = "pip", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "safe-eth-py", specifier = ">=7.18.0,<8" },
@@ -2220,19 +2220,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-helpers"
-version = "0.21.18"
+version = "0.21.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
     { name = "open-autonomy" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "toml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/8f/dd492cfe6a15080c59e0454a038392d08386900d26b88c59df25519d0ebc/open_aea_helpers-0.21.18.tar.gz", hash = "sha256:2a55fe9b437471887dc3f1334496b63f365d2690e111cf42416c1c2c7b479fe2", size = 27126, upload-time = "2026-04-16T17:43:38.791Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/9c/d00ba8599f69f736db2ce3ceda88023c85955e2484a92ed8baf52370264c/open_aea_helpers-0.21.19.tar.gz", hash = "sha256:0e005b1be53a0f3305422996c6a30ebd597ad3b9406c5a6c62382924a86efc83", size = 28293, upload-time = "2026-04-21T10:53:34.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/a1/3d85e0df9bad3a2931a5e661b97d65bfc113efbf53bd3ed1daf699540fe9/open_aea_helpers-0.21.18-py3-none-any.whl", hash = "sha256:ef41562dafbfce310ce32f77ad31e183a536372c13a2a7b5e59307584e1b6564", size = 38188, upload-time = "2026-04-16T17:43:37.957Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ce/0dc430faf05c1ead28338d1ca013ed1b9a0ebc673f58a91ee5462a8a37ed/open_aea_helpers-0.21.19-py3-none-any.whl", hash = "sha256:42bd0b54791664e1bcb873b6cae22ea1f900dfe80ca28402e07c21c7e409ed6c", size = 38704, upload-time = "2026-04-21T10:53:33.206Z" },
 ]
 
 [[package]]
@@ -3517,15 +3512,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/84/4686ee611bb020038375c5f11fe7b6b3bb94ee78614a1faba45effe51591/texttable-1.6.7.tar.gz", hash = "sha256:290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2", size = 12891, upload-time = "2022-11-23T07:18:44.102Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/a7/2c12b543f853dae886286b824200eb9d7cd2466e3d14eff1799fbe8223b9/texttable-1.6.7-py2.py3-none-any.whl", hash = "sha256:b7b68139aa8a6339d2c320ca8b1dc42d13a7831a346b446cb9eb385f0c76310c", size = 10714, upload-time = "2022-11-23T07:18:42.04Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

mech-client is a lean Python SDK with no custom AEA contract/skill surface, so the Wave 1 (dependency-cleanup) scope here is narrow:

- **Version bump**: `open-aea-helpers==0.21.18` → `==0.21.19` (tracks open-autonomy 0.21.19).
- **Third-party hash refresh**: 2 of 4 third_party entries in `packages/packages.json` updated to match `open-autonomy@v0.21.19`:
  - `connection/valory/abci/0.1.0`
  - `skill/valory/abstract_abci/0.1.0`
- **CI parity with agent repos**: added `[testenv:check-third-party-hashes]` pinned to `valory-xyz/open-autonomy@0.21.19` + `valory-xyz/open-aea@2.2.1`, wired into `workflow.yml` so drift is caught on every PR (the agent-shaped repos — trader, optimus, IEKit, meme-ooorr, market-creator — already run this check; the mech-family repos didn't).
- **Lockfile**: `uv.lock` regenerated; one stale transitive (`toml`) dropped.

No Python code changes; no contract or skill rewrites.

## Test plan

- [x] `tox -e check-third-party-hashes` → 4/4 hashes consistent with upstream
- [x] `tox -e check-hash` → OK
- [x] `tox -e black-check, isort-check, flake8, mypy, pylint, vulture, bandit` → all OK
- [x] pylint 10.00/10
- [x] `uv lock --check`

## Related

- Part of fleet-wide Wave 1 dependency-cleanup (tracking [open-autonomy#2477](https://github.com/valory-xyz/open-autonomy/pull/2477))
- mech PR: [valory-xyz/mech#436](https://github.com/valory-xyz/mech/pull/436)

🤖 Generated with [Claude Code](https://claude.com/claude-code)