### PR TITLE
chore: bump version to v0.20.2

### DIFF
--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -22,7 +22,7 @@ Example usage:
     ... )
 """
 
-__version__ = "v0.20.1"
+__version__ = "v0.20.2"
 
 # Domain models
 from mech_client.domain.tools.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mech-client"
-version = "v0.20.1"
+version = "v0.20.2"
 description = "Basic client to interact with a mech"
 requires-python = ">=3.10,<3.15"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1909,7 +1909,7 @@ wheels = [
 
 [[package]]
 name = "mech-client"
-version = "0.20.1"
+version = "0.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The v0.20.2 GitHub Release was tagged on the merge commit of #230 (`81b06d6`) but the version-bump step from `CLAUDE.md`'s release checklist was skipped, so the release workflow built `mech_client-0.20.1.whl` and PyPI rejected it with `400 File already exists` — exactly the deliberate behavior CLAUDE.md describes:
> **PyPI Publish:** Always set `skip_existing: false` in GitHub Actions to fail explicitly on duplicate versions.

This bumps `pyproject.toml`, `mech_client/__init__.py`, and `uv.lock` from v0.20.1 → v0.20.2 so the rebuilt artefact matches the tag.

## Recovery plan after merge

1. Move the existing `v0.20.2` git tag onto the new merge commit.
2. Delete and re-create the GitHub Release for `v0.20.2` (or re-run the release workflow) so it picks up the bumped version and uploads `mech_client-0.20.2.whl` to PyPI.

## Test plan

- [x] `uv lock` regenerates uv.lock with v0.20.2
- [ ] PR CI green
- [ ] After merge: tag move + release re-run uploads v0.20.2 to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)