### PR TITLE
chore: bump open-autonomy 0.21.22, open-aea 2.2.6

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,7 +1,7 @@
 {
     "dev": {
-        "agent/valory/mech_client/0.1.0": "bafybeiaudemcmceh4iukdhezxxhdypu2hwcrvrkiwl5zvhn34le2ucmziu",
-        "service/valory/mech_client/0.1.0": "bafybeihlke2upscxnrkq2gae4dsxzzncwpdqxhfawvw3zn6sesgjmwcft4"
+        "agent/valory/mech_client/0.1.0": "bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4",
+        "service/valory/mech_client/0.1.0": "bafybeie2muu4byu34wxb5hbc2jw7zaqunzqpfx6cm2wiycmezvtvdvei2a"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,7 +1,7 @@
 {
     "dev": {
-        "agent/valory/mech_client/0.1.0": "bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4",
-        "service/valory/mech_client/0.1.0": "bafybeie2muu4byu34wxb5hbc2jw7zaqunzqpfx6cm2wiycmezvtvdvei2a"
+        "agent/valory/mech_client/0.1.0": "bafybeianp75zchjncfaor57f3ivwvdgwoihxfydl7uwlvh22mhqgjs2rgq",
+        "service/valory/mech_client/0.1.0": "bafybeibvpr5b6ccwuflzqhll2hczcpcjixbobabj5hoj5nx2s6azsqggxy"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,7 +1,7 @@
 {
     "dev": {
-        "agent/valory/mech_client/0.1.0": "bafybeianp75zchjncfaor57f3ivwvdgwoihxfydl7uwlvh22mhqgjs2rgq",
-        "service/valory/mech_client/0.1.0": "bafybeibvpr5b6ccwuflzqhll2hczcpcjixbobabj5hoj5nx2s6azsqggxy"
+        "agent/valory/mech_client/0.1.0": "bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4",
+        "service/valory/mech_client/0.1.0": "bafybeie2muu4byu34wxb5hbc2jw7zaqunzqpfx6cm2wiycmezvtvdvei2a"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",

--- a/packages/valory/agents/mech_client/aea-config.yaml
+++ b/packages/valory/agents/mech_client/aea-config.yaml
@@ -46,6 +46,6 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.65.0
+    version: ==2.2.6
 customs: []
 default_connection: null

--- a/packages/valory/agents/mech_client/aea-config.yaml
+++ b/packages/valory/agents/mech_client/aea-config.yaml
@@ -46,6 +46,6 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==2.2.6
+    version: ==2.2.2
 customs: []
 default_connection: null

--- a/packages/valory/agents/mech_client/aea-config.yaml
+++ b/packages/valory/agents/mech_client/aea-config.yaml
@@ -46,6 +46,6 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==2.2.2
+    version: ==2.2.6
 customs: []
 default_connection: null

--- a/packages/valory/services/mech_client/service.yaml
+++ b/packages/valory/services/mech_client/service.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeibgcfkkosavrzc5oubkvrmq467dmpns2h54iwnlfaxlrbam5f6z5y
 fingerprint_ignore_patterns: []
 number_of_agents: 1
-agent: valory/mech_client:0.1.0:bafybeiaudemcmceh4iukdhezxxhdypu2hwcrvrkiwl5zvhn34le2ucmziu
+agent: valory/mech_client:0.1.0:bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4
 deployment: {}
 dependencies: {}
 ---

--- a/packages/valory/services/mech_client/service.yaml
+++ b/packages/valory/services/mech_client/service.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeibgcfkkosavrzc5oubkvrmq467dmpns2h54iwnlfaxlrbam5f6z5y
 fingerprint_ignore_patterns: []
 number_of_agents: 1
-agent: valory/mech_client:0.1.0:bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4
+agent: valory/mech_client:0.1.0:bafybeianp75zchjncfaor57f3ivwvdgwoihxfydl7uwlvh22mhqgjs2rgq
 deployment: {}
 dependencies: {}
 ---

--- a/packages/valory/services/mech_client/service.yaml
+++ b/packages/valory/services/mech_client/service.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeibgcfkkosavrzc5oubkvrmq467dmpns2h54iwnlfaxlrbam5f6z5y
 fingerprint_ignore_patterns: []
 number_of_agents: 1
-agent: valory/mech_client:0.1.0:bafybeianp75zchjncfaor57f3ivwvdgwoihxfydl7uwlvh22mhqgjs2rgq
+agent: valory/mech_client:0.1.0:bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4
 deployment: {}
 dependencies: {}
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10,<3.15"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "open-aea-helpers==0.21.20",
+    "open-aea-helpers==0.21.22",
     "gql>=3.4.1",
     "tabulate>=0.9.0,<0.10",
     "setuptools>=78.1.1,<82",
@@ -44,8 +44,8 @@ service_specific_packages = ["mech_client", "scripts"]
 pytest_targets = ["tests/unit"]
 # Library, not a runtime open-autonomy app — set explicitly so tomte's
 # liccheck / check-third-party-hashes envs render valid upstream pins.
-open_autonomy_version = "0.21.20"
-open_aea_version = "2.2.3"
+open_autonomy_version = "0.21.22"
+open_aea_version = "2.2.6"
 # 32-byte keccak hashes (public protocol identifiers, not credentials)
 # trip gitleaks' generic-secret rule. `marketplace_interact.py` was
 # removed in v0.17.0 but `gitleaks detect` scans full history.

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 extra_deps =
     py-multibase==1.0.3
     py-multicodec==0.2.1
-    open-autonomy[all]==0.21.20
+    open-autonomy[all]==0.21.22
     grpcio==1.78.0
     protobuf<7,>=5
 
@@ -114,7 +114,7 @@ ignore_missing_imports = True
 [Authorized Packages]
 ; open-autonomy wheel metadata reports "Other/Proprietary" due to the
 ; license-classifier mapping in its build metadata; actual license is Apache-2.0.
-open-autonomy: ==0.21.20
+open-autonomy: ==0.21.22
 ; open-aea-flashbots ships without license classifier metadata; Apache-2.0.
 open-aea-flashbots: *
 blspy: 2.0.2

--- a/uv.lock
+++ b/uv.lock
@@ -1939,7 +1939,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1,<9" },
     { name = "gql", specifier = ">=3.4.1" },
     { name = "olas-operate-middleware", specifier = ">=0.15.2,<0.16" },
-    { name = "open-aea-helpers", specifier = "==0.21.20" },
+    { name = "open-aea-helpers", specifier = "==0.21.22" },
     { name = "pip", specifier = ">=24.0" },
     { name = "py-multibase", specifier = "==1.0.3" },
     { name = "py-multicodec", specifier = "==0.2.1" },
@@ -2289,14 +2289,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-helpers"
-version = "0.21.20"
+version = "0.21.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "open-autonomy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/d4/d6ba60eebaf21a95b0b0b73e37040a18a336dd025a8bcaaeadc3b059df9f/open_aea_helpers-0.21.20.tar.gz", hash = "sha256:e89cc4fa485b5986d04831dc67ad5f765d59936b1d01e21052f76a1b53aad565", size = 28466, upload-time = "2026-05-05T17:40:20.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/46/8db346821041f301f63ea4d2519c04edb2631c4805d43fa94f12e84165b2/open_aea_helpers-0.21.22.tar.gz", hash = "sha256:c277b577a3a7ec94d5c0ed9f9e6281f8b75365207f11746026ef90635a11a507", size = 28468, upload-time = "2026-05-18T08:02:52.486Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/da/d33eca4e6bd0326b985d66ec1b9af52efc2e72982c00f3da29155b621377/open_aea_helpers-0.21.20-py3-none-any.whl", hash = "sha256:a99ab89d100d7ef5016e65c1da62e0d3e55caa566dddf2772b6158620361d2b7", size = 38923, upload-time = "2026-05-05T17:40:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d3/3cf94fe71871ee79186072729081550a00821e359650f189d6723d10f8e9/open_aea_helpers-0.21.22-py3-none-any.whl", hash = "sha256:3d08a2c02921f3e7ff68a6036afa4efbe614fa47030fd4135c1b7569fb27d35e", size = 38920, upload-time = "2026-05-18T08:02:51.652Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps mech-client onto the same OA / open-aea version the rest of the fleet just moved to.

- `[project] dependencies`: `open-aea-helpers==0.21.20 → 0.21.22` (the only direct framework pin in this repo)
- `[tool.tomte]` metadata: `open_autonomy_version "0.21.20" → "0.21.22"` and `open_aea_version "2.2.3" → "2.2.6"` (drives the version pins tomte injects into `liccheck` / `check-third-party-hashes`)
- `tox.ini`: `[tomte-extensions] extra_deps` `open-autonomy[all]==0.21.20 → 0.21.22` and `[Authorized Packages] open-autonomy: ==0.21.20 → 0.21.22`
- `packages/valory/agents/mech_client/aea-config.yaml`: stale dev plugin pin `open-aea-ledger-ethereum: ==1.65.0 → ==2.2.2` (see note 2 below)
- `packages/valory/services/mech_client/service.yaml` + `packages/packages.json`: dev fingerprints rehashed by `autonomy packages lock` (agent CID changed, service references it by CID)
- `uv.lock`: regenerated; only direct upgrade is `open-aea-helpers 0.21.20 → 0.21.22`

Non-breaking patch upgrades per upstream upgrading.md
([open-autonomy 0.21.21 → 0.21.22](https://github.com/valory-xyz/open-autonomy/blob/v0.21.22/docs/upgrading.md),
[open-aea 2.2.3 → 2.2.6](https://github.com/valory-xyz/open-aea/blob/v2.2.6/docs/upgrading.md)).
Upstream explicitly says "No agent / package / config edits are required" beyond pin changes.

## Notes specific to this repo

1. **mech-client doesn't directly pin `open-autonomy` or `open-aea` in `[project] dependencies`** — it only pins `open-aea-helpers`. The framework comes in transitively via `olas-operate-middleware` (currently resolves to `open-autonomy==0.21.19` / `open-aea==2.2.1` / `open-aea-ledger-ethereum==2.2.2` in the lockfile, bounded by `olas-operate-middleware<0.16`). The test/lint envs install `open-autonomy[all]==0.21.22` directly via `[tomte-extensions] extra_deps`. If the goal is for SDK consumers to also get 0.21.22 / 2.2.6 at install time, that's a separate follow-up (bump `olas-operate-middleware` or add a direct framework pin to `[project] dependencies`).

2. **Stale `==1.65.0` plugin pin in `aea-config.yaml`** has been bumped to `==2.2.6` (matches the OA / open-aea bump target). The pin is inert metadata in this repo — no CI job runs `aea install`, `autonomy fetch`, `build-image`, or `autonomy packages lock --check` against it, so the value carries no install-time semantics. Two alignment options were discussed during review: align with the **resolved** framework in `uv.lock` (`==2.2.2`, transitively from `olas-operate-middleware<0.16`), or align with the **target** framework on this PR (`==2.2.6`, what every other dev YAML in the fleet pins to). Settled on the target to keep the value consistent with the rest of the fleet and with the PR's own framing — the underlying resolved-vs-target divergence is the note-1 follow-up (bump `olas-operate-middleware` or add a direct framework pin in `[project] dependencies`). Last touched 2025-10-02 (commit `3c2defba`); the Oct 2025 → Wave-2a → 0.21.16rc1 → 0.21.19 → 0.21.20 bumps all missed this site, which is why the value had drifted so far.

3. **No docker image pin** in `release.yml` / `workflow.yml` — mech-client is a PyPI-published SDK, not an agent service, so there's no `valory/open-autonomy-user:<tag>` to bump.

## Test plan

Matches `.github/workflows/workflow.yml` exactly.

- [x] `uv lock --check`
- [x] `uv sync --all-groups`
- [x] `tomte check-copyright --author valory` (pre-existing local-only failure on 3 gitignored empty `__init__.py` files; these are not in the repo, won't reach CI)
- [x] `tomte tox -e liccheck`
- [x] `tomte tox -e check-third-party-hashes`
- [x] `tomte tox -p -e safety -e bandit`
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint`
- [x] `tomte tox -e gitleaks`
- [x] `uv run pytest tests/unit -v --tb=short -k "not trio" --cov=mech_client --cov-fail-under=100` — **702 passed, 100.00% coverage maintained**
- [x] `autonomy packages lock --check`
- [x] `aea --version` reports `2.2.1` (transitive via olas-operate-middleware), test-env `open-autonomy==0.21.22` installs cleanly
