### PR TITLE
chore: bump version to v0.21.0

### DIFF
--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -22,7 +22,7 @@ Example usage:
     ... )
 """
 
-__version__ = "v0.20.2"
+__version__ = "v0.21.0"
 
 # Domain models
 from mech_client.domain.tools.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mech-client"
-version = "v0.20.2"
+version = "v0.21.0"
 description = "Basic client to interact with a mech"
 requires-python = ">=3.10,<3.15"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1909,7 +1909,7 @@ wheels = [
 
 [[package]]
 name = "mech-client"
-version = "0.20.2"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Cuts a release for the open-autonomy 0.21.22 / open-aea 2.2.6 framework bump merged in #234
- Bumps `pyproject.toml`, `mech_client/__init__.py`, and `uv.lock` to `v0.21.0`
- No code or dependency changes beyond the version string

## Test plan
- [x] `uv lock --check` passes
- [x] `tomte check-copyright --author valory` (git-tracked files only)
- [x] `tomte tox -e liccheck`
- [x] `tomte tox -e check-third-party-hashes`
- [x] `tomte tox -p -e safety -e bandit`
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint`
- [x] `tomte tox -e gitleaks`
- [x] `pytest tests/unit -k "not trio" --cov-fail-under=100` — 702 passed, 100.00% coverage
- [x] `make dist` produces `mech_client-0.21.0.tar.gz` and `mech_client-0.21.0-py3-none-any.whl`

After merge: tag `v0.21.0` on the merge commit so the release workflow publishes the matching artefact to PyPI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)