### PR TITLE
chore: bump open-autonomy 0.21.23, open-aea 2.2.7

### DIFF
--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -22,7 +22,7 @@ Example usage:
     ... )
 """
 
-__version__ = "v0.21.0"
+__version__ = "v0.21.1"
 
 # Domain models
 from mech_client.domain.tools.models import (

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,12 +1,12 @@
 {
     "dev": {
-        "agent/valory/mech_client/0.1.0": "bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4",
-        "service/valory/mech_client/0.1.0": "bafybeie2muu4byu34wxb5hbc2jw7zaqunzqpfx6cm2wiycmezvtvdvei2a"
+        "agent/valory/mech_client/0.1.0": "bafybeifrxnc3drhtzrbqxatr4u23v5lja7hakdgrqiz6xolyz2gwqsxziq",
+        "service/valory/mech_client/0.1.0": "bafybeiejakf2vcgl3wxya4p32qcg5g2zieq52u5a3wdggbalt2hu2x62lq"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
-        "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
-        "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54"
+        "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
+        "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi"
     }
 }

--- a/packages/valory/agents/mech_client/aea-config.yaml
+++ b/packages/valory/agents/mech_client/aea-config.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeihsqhvkxixnofpz4bcwqdgydgqxcdlliikszucwvfquooygqxkle4
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu
+- valory/abci:0.1.0:bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi
 contracts: []
 protocols:
 - open_aea/signing:1.0.0:bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye
 - valory/abci:0.1.0:bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte
 skills:
-- valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
+- valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -46,6 +46,6 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==2.2.6
+    version: ==2.2.7
 customs: []
 default_connection: null

--- a/packages/valory/services/mech_client/service.yaml
+++ b/packages/valory/services/mech_client/service.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeibgcfkkosavrzc5oubkvrmq467dmpns2h54iwnlfaxlrbam5f6z5y
 fingerprint_ignore_patterns: []
 number_of_agents: 1
-agent: valory/mech_client:0.1.0:bafybeif3azn4azaopsup5lrh4r2ixvkd7in2zgwhlqckut5qphsfgrfnc4
+agent: valory/mech_client:0.1.0:bafybeifrxnc3drhtzrbqxatr4u23v5lja7hakdgrqiz6xolyz2gwqsxziq
 deployment: {}
 dependencies: {}
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "mech-client"
-version = "v0.21.0"
+version = "v0.21.1"
 description = "Basic client to interact with a mech"
 requires-python = ">=3.10,<3.15"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "open-aea-helpers==0.21.22",
+    "open-aea-helpers==0.21.23",
     "gql>=3.4.1",
     "tabulate>=0.9.0,<0.10",
     "setuptools>=78.1.1,<82",
@@ -44,8 +44,8 @@ service_specific_packages = ["mech_client", "scripts"]
 pytest_targets = ["tests/unit"]
 # Library, not a runtime open-autonomy app — set explicitly so tomte's
 # liccheck / check-third-party-hashes envs render valid upstream pins.
-open_autonomy_version = "0.21.22"
-open_aea_version = "2.2.6"
+open_autonomy_version = "0.21.23"
+open_aea_version = "2.2.7"
 # 32-byte keccak hashes (public protocol identifiers, not credentials)
 # trip gitleaks' generic-secret rule. `marketplace_interact.py` was
 # removed in v0.17.0 but `gitleaks detect` scans full history.

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 extra_deps =
     py-multibase==1.0.3
     py-multicodec==0.2.1
-    open-autonomy[all]==0.21.22
+    open-autonomy[all]==0.21.23
     grpcio==1.78.0
     protobuf<7,>=5
 
@@ -114,7 +114,7 @@ ignore_missing_imports = True
 [Authorized Packages]
 ; open-autonomy wheel metadata reports "Other/Proprietary" due to the
 ; license-classifier mapping in its build metadata; actual license is Apache-2.0.
-open-autonomy: ==0.21.22
+open-autonomy: ==0.21.23
 ; open-aea-flashbots ships without license classifier metadata; Apache-2.0.
 open-aea-flashbots: *
 blspy: 2.0.2

--- a/uv.lock
+++ b/uv.lock
@@ -1909,7 +1909,7 @@ wheels = [
 
 [[package]]
 name = "mech-client"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1939,7 +1939,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1,<9" },
     { name = "gql", specifier = ">=3.4.1" },
     { name = "olas-operate-middleware", specifier = ">=0.15.2,<0.16" },
-    { name = "open-aea-helpers", specifier = "==0.21.22" },
+    { name = "open-aea-helpers", specifier = "==0.21.23" },
     { name = "pip", specifier = ">=24.0" },
     { name = "py-multibase", specifier = "==1.0.3" },
     { name = "py-multicodec", specifier = "==0.2.1" },
@@ -2289,14 +2289,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-helpers"
-version = "0.21.22"
+version = "0.21.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "open-autonomy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/46/8db346821041f301f63ea4d2519c04edb2631c4805d43fa94f12e84165b2/open_aea_helpers-0.21.22.tar.gz", hash = "sha256:c277b577a3a7ec94d5c0ed9f9e6281f8b75365207f11746026ef90635a11a507", size = 28468, upload-time = "2026-05-18T08:02:52.486Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/de/dc99f0d1430af94a0515f80bc9b4188202400409866952b983daa4be1b63/open_aea_helpers-0.21.23.tar.gz", hash = "sha256:fefb77d9cb2b3c410aacb913c86418567a714d8f2cb5c47878964a9ee99a7c09", size = 41107, upload-time = "2026-05-28T16:57:57.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d3/3cf94fe71871ee79186072729081550a00821e359650f189d6723d10f8e9/open_aea_helpers-0.21.22-py3-none-any.whl", hash = "sha256:3d08a2c02921f3e7ff68a6036afa4efbe614fa47030fd4135c1b7569fb27d35e", size = 38920, upload-time = "2026-05-18T08:02:51.652Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/03/554d7310fd3bdcded09925905ab5cbe70e5fe8377f02571bdbfa460b890a/open_aea_helpers-0.21.23-py3-none-any.whl", hash = "sha256:7c31f33279a210d15eb0472a41fe794aaf13a870b23e862697f27b2c33d61e40", size = 44415, upload-time = "2026-05-28T16:57:56.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps mech-client onto the latest OA / open-aea patch releases and ships a matching mech-client patch version.

- `[project] dependencies`: `open-aea-helpers==0.21.22 → 0.21.23` (the only direct framework pin in this repo)
- `[tool.tomte]` metadata: `open_autonomy_version "0.21.22" → "0.21.23"` and `open_aea_version "2.2.6" → "2.2.7"` (drives the version pins tomte injects into `liccheck` / `check-third-party-hashes`)
- `tox.ini`: `[tomte-extensions] extra_deps` `open-autonomy[all]==0.21.22 → 0.21.23` and `[Authorized Packages] open-autonomy: ==0.21.22 → 0.21.23`
- `packages/valory/agents/mech_client/aea-config.yaml`: dev plugin pin `open-aea-ledger-ethereum: ==2.2.6 → ==2.2.7`, plus refreshed `valory/abci` connection + `valory/abstract_abci` skill CIDs from `valory-xyz/open-autonomy:v0.21.23`
- `packages/valory/services/mech_client/service.yaml` + `packages/packages.json`: dev fingerprints rehashed by `autonomy packages lock` (agent CID changed, service references it by CID)
- `mech_client/__init__.py` + `pyproject.toml [project] version`: mech-client `v0.21.0 → v0.21.1`
- `uv.lock`: regenerated; only direct upgrades are `open-aea-helpers 0.21.22 → 0.21.23` and `mech-client 0.21.0 → 0.21.1`

Non-breaking patch upgrades per upstream upgrading.md
([open-autonomy 0.21.22 → 0.21.23](https://github.com/valory-xyz/open-autonomy/blob/v0.21.23/docs/upgrading.md),
[open-aea 2.2.6 → 2.2.7](https://github.com/valory-xyz/open-aea/blob/v2.2.7/docs/upgrading.md)).

## Notes specific to this repo

1. **mech-client doesn't directly pin `open-autonomy` or `open-aea` in `[project] dependencies`** — it only pins `open-aea-helpers`. The framework comes in transitively via `olas-operate-middleware`, which still resolves to `open-autonomy==0.21.19` / `open-aea==2.2.1` / `open-aea-ledger-ethereum==2.2.2` in the lockfile (bounded by `olas-operate-middleware<0.16`). The test/lint envs install `open-autonomy[all]==0.21.23` directly via `[tomte-extensions] extra_deps`. If the goal is for SDK consumers to also get 0.21.23 / 2.2.7 at install time, that's a separate follow-up (bump `olas-operate-middleware` or add a direct framework pin to `[project] dependencies`).

2. **Operator-visible logging change in open-aea 2.2.7 not applied here.** OA 0.21.23's upgrading guide step 3 asks downstreams to add a `root:` block to `aea-config.yaml`'s `logging_config` — otherwise third-party `INFO`/`DEBUG` log lines (`web3`, `urllib3`, `requests`) go silent under the new open-aea after the orphan stderr `StreamHandler` removal. Skipped on this PR by choice; can be applied in a follow-up if anyone runs `packages/valory/agents/mech_client` as a live agent.

3. **No docker image pin** in `release.yml` / `workflow.yml` — mech-client is a PyPI-published SDK, not an agent service, so there's no `valory/open-autonomy-user:<tag>` to bump.

## Test plan

Matches `.github/workflows/workflow.yml` exactly.

- [x] `uv lock --check`
- [x] `uv sync --all-groups`
- [x] `tomte tox -e liccheck`
- [x] `tomte tox -e check-third-party-hashes` (all 4 third-party CIDs consistent with valory-xyz/open-autonomy@v0.21.23 + valory-xyz/open-aea@v2.2.7)
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` (pylint 10.00/10)
- [x] `tomte tox -e bandit`
- [x] `tomte tox -e gitleaks`
- [x] `uv run pytest tests/unit -v --tb=short -k "not trio" --cov=mech_client --cov-fail-under=100` — **702 passed, 100.00% coverage maintained**
- [x] `autonomy packages lock --check`
- [x] `make dist` builds `mech_client-0.21.1.tar.gz` + `mech_client-0.21.1-py3-none-any.whl`