### PR TITLE
feat(offchain): structured 402 payment handling + auto-deposit [WS-2]

### DIFF
--- a/mech_client/cli/commands/request_cmd.py
+++ b/mech_client/cli/commands/request_cmd.py
@@ -72,7 +72,8 @@ def _format_delivery_output(delivery_data: Any) -> str:
 )
 @click.option(
     "--auto-deposit",
-    type=bool,
+    is_flag=True,
+    default=False,
     help="On an offchain HTTP 402, top up the prepaid balance and retry.",
 )
 @click.option(
@@ -176,7 +177,6 @@ def request(
     # Process flags
     use_offchain = use_offchain or False
     use_prepaid = use_prepaid or use_offchain
-    auto_deposit = auto_deposit or False
 
     # Validate tools
     if not tools:

--- a/mech_client/cli/commands/request_cmd.py
+++ b/mech_client/cli/commands/request_cmd.py
@@ -71,6 +71,11 @@ def _format_delivery_output(delivery_data: Any) -> str:
     help="Use offchain mech (URL discovered from on-chain metadata).",
 )
 @click.option(
+    "--auto-deposit",
+    type=bool,
+    help="On an offchain HTTP 402, top up the prepaid balance and retry.",
+)
+@click.option(
     "--tools",
     type=str,
     multiple=True,
@@ -109,6 +114,7 @@ def request(
     chain_config: str,
     use_prepaid: bool,
     use_offchain: bool,
+    auto_deposit: bool,
     key: Optional[str],
     tools: Optional[tuple],
     extra_attribute: Optional[List[str]] = None,
@@ -138,6 +144,7 @@ def request(
     :param chain_config: Chain configuration name (gnosis, base, polygon, optimism).
     :param use_prepaid: Use the marketplace prepaid balance instead of per-request payment.
     :param use_offchain: Route delivery off-chain (auto-discovered URL); implies prepaid.
+    :param auto_deposit: On an offchain HTTP 402, top up the prepaid balance and retry.
     :param key: Optional path to a private-key file (required in client mode).
     :param tools: One or more tool names matching ``prompts`` positionally.
     :param extra_attribute: Optional ``key=value`` extras attached to each request.
@@ -169,6 +176,7 @@ def request(
     # Process flags
     use_offchain = use_offchain or False
     use_prepaid = use_prepaid or use_offchain
+    auto_deposit = auto_deposit or False
 
     # Validate tools
     if not tools:
@@ -204,6 +212,7 @@ def request(
             priority_mech=priority_mech,
             use_prepaid=use_prepaid,
             use_offchain=use_offchain,
+            auto_deposit=auto_deposit,
             extra_attributes=extra_attributes_dict,
             timeout=timeout,
         )

--- a/mech_client/cli/commands/request_cmd.py
+++ b/mech_client/cli/commands/request_cmd.py
@@ -74,7 +74,12 @@ def _format_delivery_output(delivery_data: Any) -> str:
     "--auto-deposit",
     is_flag=True,
     default=False,
-    help="On an offchain HTTP 402, top up the prepaid balance and retry.",
+    help=(
+        "On an offchain HTTP 402, top up the prepaid balance and retry. "
+        "Trusts the mech's reported shortfall, capped at 10x the signed "
+        "max_delivery_rate; above that the request is refused so the user "
+        "can deposit manually."
+    ),
 )
 @click.option(
     "--tools",

--- a/mech_client/infrastructure/ipfs/local_cid.py
+++ b/mech_client/infrastructure/ipfs/local_cid.py
@@ -154,16 +154,17 @@ def _multibase_base32_lower(payload: bytes) -> str:
     return "b" + encoded
 
 
-def compute_cidv1(content: bytes) -> str:
-    """Compute the CIDv1 string a real ``ipfs add`` would produce for ``content``.
+def compute_cidv1_bytes(content: bytes) -> bytes:
+    """Compute the raw CIDv1 bytes (no multibase prefix) for ``content``.
 
-    The output is byte-for-byte equivalent to running
-    ``ipfs add --cid-version=1 --raw-leaves=false`` on the same content. The
-    returned string is a multibase base32-lower (``bafy...``) DAG-PB CIDv1 over
-    a SHA-256 multihash of the UnixFS-wrapped content.
+    Returns ``[version=0x01, codec=0x70, multihash code=0x12, digest length=0x20,
+    32 sha256 bytes]`` — the same bytes ``ipfs add --cid-version=1
+    --raw-leaves=false`` commits to, before multibase encoding. Use this when
+    the caller wants the legacy ``f01...`` hex form and would otherwise
+    multibase-encode + immediately multibase-decode the result.
 
     :param content: the content bytes to commit to.
-    :return: the multibase-encoded CIDv1 string.
+    :return: the raw CIDv1 bytes (version + codec + multihash).
     :raises ValueError: if ``content`` exceeds the single-block bound; chunked
         DAGs are intentionally unsupported (offchain payloads are well under
         256 KiB today and the unbounded path needs a different DAG shape).
@@ -179,6 +180,19 @@ def compute_cidv1(content: bytes) -> str:
 
     digest = hashlib.sha256(dag_pb_bytes).digest()
     multihash = bytes([_SHA256_MULTIHASH_CODE, _SHA256_DIGEST_LEN]) + digest
-    cid_bytes = bytes([_CIDV1_VERSION, _DAG_PB_CODEC]) + multihash
+    return bytes([_CIDV1_VERSION, _DAG_PB_CODEC]) + multihash
 
-    return _multibase_base32_lower(cid_bytes)
+
+def compute_cidv1(content: bytes) -> str:
+    """Compute the CIDv1 string a real ``ipfs add`` would produce for ``content``.
+
+    The output is byte-for-byte equivalent to running
+    ``ipfs add --cid-version=1 --raw-leaves=false`` on the same content. The
+    returned string is a multibase base32-lower (``bafy...``) DAG-PB CIDv1 over
+    a SHA-256 multihash of the UnixFS-wrapped content. Delegates the oversize
+    check to ``compute_cidv1_bytes``.
+
+    :param content: the content bytes to commit to.
+    :return: the multibase-encoded CIDv1 string.
+    """
+    return _multibase_base32_lower(compute_cidv1_bytes(content))

--- a/mech_client/infrastructure/ipfs/local_cid.py
+++ b/mech_client/infrastructure/ipfs/local_cid.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Pure-Python local CIDv1 computation matching IPFS UnixFS + DAG-PB single-block output.
+
+Produces the same CIDv1 string that ``ipfs add --cid-version=1 --raw-leaves=false``
+would for the same bytes. Intended for the offchain request path where the client
+puts the content commitment on chain (via the signed request) without publishing
+the content to public IPFS.
+
+This is the requester-side mirror of the mech's
+``packages/valory/skills/task_execution/utils/local_cid.py``. Both implementations
+must produce byte-identical CIDs for the same input: the mech-client signs over
+the CID, the mech recomputes the CID locally and compares. A drift between the
+two encoders breaks signature verification and rejects every request. The shared
+parity fixture in ``tests/unit/infrastructure/test_local_cid.py`` locks the two
+together — every (content, CID) pair listed there is reproduced by running
+``ipfs add --cid-version=1 --raw-leaves=false`` on the same input, and the same
+pairs appear in the mech's test suite.
+
+Single-block only: content must fit in one IPFS block. IPFS chunks at 256 KiB by
+default, so the single-block bound is exactly 256 KiB; payloads above it need a
+chunked / linked DAG and are not handled here. ``compute_cidv1`` raises
+``ValueError`` (not ``assert``, which ``python -O`` would strip) above the bound,
+so a future oversized prompt fails loudly rather than silently producing a CID
+the mech's local recomputation would not match.
+
+Shape note: this is a *bare* single-block file CID, matching ``ipfs add`` without
+``-w``. The legacy on-chain delivery path on the mech uploads via the IPFS
+connection with ``wrap_with_directory=True``, committing the *directory* CID.
+The two paths therefore commit structurally different CIDs for the same content
+— intentional: offchain content is never published, so its commitment is verified
+by re-hashing the raw bytes as a bare file, not by resolving
+``ipfs://<cid>/<req_id>``.
+"""
+
+import base64
+import hashlib
+
+_MAX_BLOCK_BYTES = (
+    256 * 1024
+)  # IPFS default chunk size; above this needs a multi-block DAG.
+
+# Multicodec / multihash / multibase prefix bytes.
+_CIDV1_VERSION = 0x01
+_DAG_PB_CODEC = 0x70
+_SHA256_MULTIHASH_CODE = 0x12
+_SHA256_DIGEST_LEN = 0x20
+
+# UnixFS data type enum: File = 2.
+_UNIXFS_TYPE_FILE = 2
+
+
+def _varint(value: int) -> bytes:
+    """Encode an unsigned integer as a protobuf varint.
+
+    :param value: the non-negative integer to encode.
+    :return: the encoded varint bytes.
+    :raises ValueError: if ``value`` is negative.
+    """
+    if value < 0:
+        raise ValueError("varint requires non-negative value")
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _length_delimited(field_number: int, payload: bytes) -> bytes:
+    """Encode a protobuf length-delimited field (wire type 2).
+
+    :param field_number: the protobuf field number.
+    :param payload: the field payload bytes.
+    :return: the encoded tag + length + payload.
+    """
+    tag = (field_number << 3) | 2
+    return _varint(tag) + _varint(len(payload)) + payload
+
+
+def _varint_field(field_number: int, value: int) -> bytes:
+    """Encode a protobuf varint field (wire type 0).
+
+    :param field_number: the protobuf field number.
+    :param value: the field value.
+    :return: the encoded tag + value.
+    """
+    tag = (field_number << 3) | 0
+    return _varint(tag) + _varint(value)
+
+
+def _encode_unixfs_file(content: bytes) -> bytes:
+    """Encode a UnixFS ``Type=File`` Data message for the given content.
+
+    Mirrors the canonical encoding go-ipfs produces for a single-block file: a
+    Type varint (field 1), optional Data bytes (field 2), and the filesize
+    varint (field 3). The Data field is omitted entirely for empty content,
+    matching go-ipfs' behaviour.
+
+    :param content: the raw file content.
+    :return: the serialized UnixFS message bytes.
+    """
+    out = bytearray()
+    out += _varint_field(1, _UNIXFS_TYPE_FILE)
+    if content:
+        out += _length_delimited(2, content)
+    out += _varint_field(3, len(content))
+    return bytes(out)
+
+
+def _encode_dag_pb_node(data: bytes) -> bytes:
+    """Wrap ``data`` in a DAG-PB ``PBNode`` with no links.
+
+    The DAG-PB ``PBNode`` schema has ``Data`` as field 1 and ``Links`` as field 2.
+    For a single-block file we have no links, only the Data field carrying the
+    serialized UnixFS message.
+
+    :param data: the serialized UnixFS bytes to wrap.
+    :return: the serialized DAG-PB node bytes.
+    """
+    return _length_delimited(1, data)
+
+
+def _multibase_base32_lower(payload: bytes) -> str:
+    """Encode bytes as RFC 4648 base32 lowercase without padding, prefixed with 'b'.
+
+    Multibase prefix ``b`` selects base32-lower; this is the encoding ``ipfs add
+    --cid-version=1`` emits by default (CIDs starting with ``bafy...`` for
+    DAG-PB).
+
+    :param payload: the bytes to multibase-encode.
+    :return: the multibase string with the ``b`` prefix.
+    """
+    encoded = base64.b32encode(payload).decode("ascii").rstrip("=").lower()
+    return "b" + encoded
+
+
+def compute_cidv1(content: bytes) -> str:
+    """Compute the CIDv1 string a real ``ipfs add`` would produce for ``content``.
+
+    The output is byte-for-byte equivalent to running
+    ``ipfs add --cid-version=1 --raw-leaves=false`` on the same content. The
+    returned string is a multibase base32-lower (``bafy...``) DAG-PB CIDv1 over
+    a SHA-256 multihash of the UnixFS-wrapped content.
+
+    :param content: the content bytes to commit to.
+    :return: the multibase-encoded CIDv1 string.
+    :raises ValueError: if ``content`` exceeds the single-block bound; chunked
+        DAGs are intentionally unsupported (offchain payloads are well under
+        256 KiB today and the unbounded path needs a different DAG shape).
+    """
+    if len(content) > _MAX_BLOCK_BYTES:
+        raise ValueError(
+            f"content size {len(content)} exceeds single-block bound "
+            f"{_MAX_BLOCK_BYTES}; chunked DAG encoding is not supported"
+        )
+
+    unixfs_bytes = _encode_unixfs_file(content)
+    dag_pb_bytes = _encode_dag_pb_node(unixfs_bytes)
+
+    digest = hashlib.sha256(dag_pb_bytes).digest()
+    multihash = bytes([_SHA256_MULTIHASH_CODE, _SHA256_DIGEST_LEN]) + digest
+    cid_bytes = bytes([_CIDV1_VERSION, _DAG_PB_CODEC]) + multihash
+
+    return _multibase_base32_lower(cid_bytes)

--- a/mech_client/infrastructure/ipfs/metadata.py
+++ b/mech_client/infrastructure/ipfs/metadata.py
@@ -25,10 +25,8 @@ import tempfile
 import uuid
 from typing import Any, Dict, Optional, Tuple
 
-import multibase
-import multicodec
 from mech_client.infrastructure.ipfs.client import IPFSClient
-from mech_client.infrastructure.ipfs.local_cid import compute_cidv1
+from mech_client.infrastructure.ipfs.local_cid import compute_cidv1_bytes
 
 
 def fetch_ipfs_hash(
@@ -65,15 +63,13 @@ def fetch_ipfs_hash(
     # the request is rejected.
     ipfs_data = json.dumps(metadata)
 
-    # Compute the CIDv1 in-process. ``compute_cidv1`` already returns a
-    # base32-lower multibase CIDv1 (``bafy...``); convert to the legacy
-    # ``f01...`` hex form the downstream truncation math expects (multibase
-    # 'f' + version '01' + dag-pb codec '70' + sha256 multihash code '12' +
-    # length '20' + 32 hex bytes of digest).
-    cidv1 = compute_cidv1(ipfs_data.encode("utf-8"))
-    cid_bytes = multibase.decode(cidv1)
-    multihash_bytes = multicodec.remove_prefix(cid_bytes)
-    v1_file_hash_hex = "f01" + multihash_bytes.hex()
+    # Compute the CIDv1 in-process and emit the legacy ``f01...`` hex form
+    # the downstream truncation math expects (multibase 'f' + version '01' +
+    # dag-pb codec '70' + sha256 multihash code '12' + length '20' + 32 hex
+    # bytes of digest). ``compute_cidv1_bytes`` returns the raw CID bytes so
+    # we can hex-encode directly — no multibase / multicodec round-trip.
+    cid_bytes = compute_cidv1_bytes(ipfs_data.encode("utf-8"))
+    v1_file_hash_hex = "f" + cid_bytes.hex()
 
     # Truncate hash for on-chain use (remove first 9 chars and add 0x prefix)
     truncated_hash = "0x" + v1_file_hash_hex[9:]

--- a/mech_client/infrastructure/ipfs/metadata.py
+++ b/mech_client/infrastructure/ipfs/metadata.py
@@ -25,7 +25,10 @@ import tempfile
 import uuid
 from typing import Any, Dict, Optional, Tuple
 
+import multibase
+import multicodec
 from mech_client.infrastructure.ipfs.client import IPFSClient
+from mech_client.infrastructure.ipfs.local_cid import compute_cidv1
 
 
 def fetch_ipfs_hash(
@@ -34,11 +37,15 @@ def fetch_ipfs_hash(
     extra_attributes: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, str, str]:
     """
-    Create metadata and compute IPFS hash without uploading.
+    Build offchain request metadata and compute its content CID locally.
 
-    Used for offchain requests where the offchain mech handles IPFS upload.
-    Creates a JSON metadata file, computes its IPFS hash, and returns both
-    the hash and the metadata content.
+    Used for offchain requests where the offchain mech never publishes the
+    content to public IPFS. The CID is computed entirely in-process via
+    ``compute_cidv1`` — no IPFS daemon is contacted, so the prompt and any
+    extra attributes never leave the requester's process. The returned CID
+    is byte-identical to what the mech computes locally on receipt, so the
+    requester's signature over the CID verifies against the mech's
+    recomputed value.
 
     :param prompt: Prompt string
     :param tool: Tool string
@@ -52,23 +59,25 @@ def fetch_ipfs_hash(
     if extra_attributes:
         metadata.update(extra_attributes)
 
-    # Convert metadata to JSON string for offchain transmission
+    # Convert metadata to JSON string for offchain transmission. The exact
+    # bytes hashed below MUST match the bytes the mech receives in ipfs_data,
+    # otherwise the mech's local recomputation produces a different CID and
+    # the request is rejected.
     ipfs_data = json.dumps(metadata)
 
-    dirpath = tempfile.mkdtemp()
-    try:
-        file_name = dirpath + "/metadata.json"
-        with open(file_name, "w", encoding="utf-8") as f:
-            json.dump(metadata, f)
+    # Compute the CIDv1 in-process. ``compute_cidv1`` already returns a
+    # base32-lower multibase CIDv1 (``bafy...``); convert to the legacy
+    # ``f01...`` hex form the downstream truncation math expects (multibase
+    # 'f' + version '01' + dag-pb codec '70' + sha256 multihash code '12' +
+    # length '20' + 32 hex bytes of digest).
+    cidv1 = compute_cidv1(ipfs_data.encode("utf-8"))
+    cid_bytes = multibase.decode(cidv1)
+    multihash_bytes = multicodec.remove_prefix(cid_bytes)
+    v1_file_hash_hex = "f01" + multihash_bytes.hex()
 
-        client = IPFSClient()
-        _, v1_file_hash_hex = client.upload(file_name, pin=False)
-
-        # Truncate hash for on-chain use (remove first 9 chars and add 0x prefix)
-        truncated_hash = "0x" + v1_file_hash_hex[9:]
-        return truncated_hash, v1_file_hash_hex, ipfs_data
-    finally:
-        shutil.rmtree(dirpath, ignore_errors=True)
+    # Truncate hash for on-chain use (remove first 9 chars and add 0x prefix)
+    truncated_hash = "0x" + v1_file_hash_hex[9:]
+    return truncated_hash, v1_file_hash_hex, ipfs_data
 
 
 def push_metadata_to_ipfs(

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -42,6 +42,12 @@ from web3.contract import Contract as Web3Contract
 
 logger = logging.getLogger(__name__)
 
+# HTTP status the offchain mech returns when the requester's prepaid balance is
+# insufficient (structured 402 challenge, see mech task_execution handlers).
+HTTP_PAYMENT_REQUIRED = 402
+# Outbound HTTP timeout (seconds) for the offchain request POST.
+OFFCHAIN_HTTP_TIMEOUT = 30
+
 
 class MarketplaceService(
     BaseTransactionService
@@ -90,6 +96,7 @@ class MarketplaceService(
         priority_mech: Optional[str] = None,
         use_prepaid: bool = False,
         use_offchain: bool = False,
+        auto_deposit: bool = False,
         extra_attributes: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
@@ -101,6 +108,8 @@ class MarketplaceService(
         :param priority_mech: Priority mech address (optional)
         :param use_prepaid: Use prepaid balance instead of per-request payment
         :param use_offchain: Use offchain mech (URL discovered from metadata)
+        :param auto_deposit: On an offchain HTTP 402, top up the prepaid balance
+            with the shortfall and retry once (only applies to the offchain path)
         :param extra_attributes: Extra attributes for metadata
         :param timeout: Timeout for delivery watching
         :return: Dictionary with request results
@@ -147,6 +156,7 @@ class MarketplaceService(
                 mech_offchain_url=offchain_url,
                 extra_attributes=extra_attributes,
                 timeout=timeout or 300.0,
+                auto_deposit=auto_deposit,
             )
 
         # On-chain flow
@@ -243,6 +253,7 @@ class MarketplaceService(
         mech_offchain_url: str,
         extra_attributes: Optional[Dict[str, Any]],
         timeout: float,
+        auto_deposit: bool = False,
     ) -> Dict[str, Any]:
         """
         Send offchain request to mech HTTP endpoint.
@@ -257,6 +268,7 @@ class MarketplaceService(
         :param mech_offchain_url: Base URL of offchain mech
         :param extra_attributes: Extra attributes for metadata
         :param timeout: Delivery watching timeout
+        :param auto_deposit: On a 402, deposit the shortfall and retry once
         :return: Dictionary with request results
         """
         logger.info("Sending offchain mech marketplace request...")
@@ -315,14 +327,11 @@ class MarketplaceService(
                 "ipfs_data": ipfs_data,
             }
 
-            # Send HTTP POST request
+            # Send HTTP POST request (handles a structured 402 + receipt header)
             url = f"{mech_offchain_url.rstrip('/')}/send_signed_requests"
             try:
-                response = requests.post(
-                    url=url,
-                    data=payload,
-                    headers={"Content-Type": "application/json"},
-                    timeout=30,
+                response = self._post_offchain_request(
+                    url, payload, payment_type, auto_deposit
                 )
                 if not response.ok:
                     reason = ""
@@ -354,6 +363,126 @@ class MarketplaceService(
             "delivery_results": results,
             "receipt": None,  # No receipt for offchain requests
         }
+
+    def _post_offchain_request(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        payment_type: PaymentType,
+        auto_deposit: bool,
+    ) -> requests.Response:
+        """POST an offchain request, handling a structured HTTP 402.
+
+        On a 402 (insufficient prepaid balance) the mech returns a structured
+        challenge. When ``auto_deposit`` is set, the shortfall is deposited and
+        the request is retried once; otherwise an actionable error is raised.
+        A ``Payment-Receipt`` header on the response is logged.
+
+        :param url: the mech's ``/send_signed_requests`` endpoint.
+        :param payload: the signed request payload.
+        :param payment_type: the request's payment type (for the deposit asset).
+        :param auto_deposit: whether to auto-deposit + retry once on a 402.
+        :return: the (possibly retried) HTTP response.
+        :raises ValueError: on a 402 when auto-deposit is disabled.
+        """
+        response = requests.post(
+            url=url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=OFFCHAIN_HTTP_TIMEOUT,
+        )
+        if response.status_code == HTTP_PAYMENT_REQUIRED:
+            challenge = self._parse_402_challenge(response)
+            if not auto_deposit:
+                raise ValueError(
+                    "Offchain request requires payment: need "
+                    f"{challenge['required']} (current balance "
+                    f"{challenge['current_balance']}) deposited to "
+                    f"{challenge['pay_to']}. Re-run with auto-deposit enabled or "
+                    f"top up your prepaid balance. ({challenge['error']})"
+                )
+            self._auto_deposit_for_402(payment_type, challenge)
+            response = requests.post(
+                url=url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=OFFCHAIN_HTTP_TIMEOUT,
+            )
+        self._log_payment_receipt(response)
+        return response
+
+    @staticmethod
+    def _parse_402_challenge(response: requests.Response) -> Dict[str, Any]:
+        """Parse the structured 402 challenge body + WWW-Authenticate header.
+
+        :param response: the 402 HTTP response from the mech.
+        :return: the normalised challenge: required, current_balance, pay_to,
+            asset, chain_id, error.
+        """
+        authenticate = response.headers.get("WWW-Authenticate")
+        if authenticate:
+            logger.info(f"Mech payment challenge: {authenticate}")
+        try:
+            body = response.json()
+        except ValueError:
+            body = {}
+        return {
+            "required": int(body.get("required", 0) or 0),
+            "current_balance": int(body.get("currentBalance", 0) or 0),
+            "pay_to": body.get("payTo", ""),
+            "asset": body.get("asset", ""),
+            "chain_id": int(body.get("chainId", 0) or 0),
+            "error": body.get("error", "payment required"),
+        }
+
+    def _auto_deposit_for_402(
+        self, payment_type: PaymentType, challenge: Dict[str, Any]
+    ) -> None:
+        """Deposit the 402 shortfall into the prepaid balance.
+
+        :param payment_type: the request's payment type (native vs token).
+        :param challenge: the parsed 402 challenge.
+        :raises ValueError: if the payment type doesn't support auto-deposit.
+        """
+        shortfall = challenge["required"] - challenge["current_balance"]
+        if shortfall <= 0:
+            return
+        # Imported here to avoid a circular import at module load.
+        from mech_client.services.deposit_service import (  # pylint: disable=import-outside-toplevel
+            DepositService,
+        )
+
+        deposit_service = DepositService(
+            chain_config=self.chain_config,
+            agent_mode=self.agent_mode,
+            crypto=self.crypto,
+            safe_address=self.safe_address,
+            ethereum_client=self.ethereum_client,
+        )
+        logger.info(f"Auto-depositing {shortfall} to top up the prepaid balance...")
+        # Explicit per-type dispatch (not is_native/is_token, which group the NVM
+        # subscription types in — those use a subscription, not a balance-tracker
+        # deposit, so auto-deposit doesn't apply to them).
+        if payment_type == PaymentType.NATIVE:
+            deposit_service.deposit_native(shortfall)
+        elif payment_type == PaymentType.OLAS_TOKEN:
+            deposit_service.deposit_token(shortfall, "olas")
+        elif payment_type == PaymentType.USDC_TOKEN:
+            deposit_service.deposit_token(shortfall, "usdc")
+        else:
+            raise ValueError(
+                f"Auto-deposit is not supported for payment type {payment_type.name}"
+            )
+
+    @staticmethod
+    def _log_payment_receipt(response: requests.Response) -> None:
+        """Log the ``Payment-Receipt`` header if the mech returned one.
+
+        :param response: the HTTP response from the mech.
+        """
+        receipt = response.headers.get("Payment-Receipt")
+        if receipt:
+            logger.info(f"Payment-Receipt: {receipt}")
 
     def _validate_tools(self, tools: Tuple[str, ...], service_id: int) -> None:
         """

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -20,7 +20,8 @@
 """Marketplace service for orchestrating mech requests."""
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
 
 import requests
 from aea_ledger_ethereum import EthereumCrypto
@@ -47,6 +48,62 @@ logger = logging.getLogger(__name__)
 HTTP_PAYMENT_REQUIRED = 402
 # Outbound HTTP timeout (seconds) for the offchain request POST.
 OFFCHAIN_HTTP_TIMEOUT = 30
+# Payment types that ``_auto_deposit_for_402`` knows how to top up via the
+# balance tracker. NVM subscription types (``NATIVE_NVM`` / ``TOKEN_NVM_USDC``)
+# are intentionally excluded: they're paid via subscription, not via a
+# balance-tracker deposit. Listing the supported set explicitly (rather than
+# falling through ``if/elif/else``) makes the contract visible — a sixth
+# ``PaymentType`` added later forces this set and the dispatch below to be
+# updated together, surfacing the gap statically instead of at offchain-402
+# runtime.
+_SUPPORTED_DEPOSIT_PAYMENT_TYPES: FrozenSet[PaymentType] = frozenset(
+    {PaymentType.NATIVE, PaymentType.OLAS_TOKEN, PaymentType.USDC_TOKEN}
+)
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    """Coerce ``value`` to ``int`` with a numeric fallback.
+
+    The 402 challenge body comes from an untrusted source (the mech). A buggy
+    or hostile mech can send ``"required": "N/A"`` or similar non-numeric
+    strings; ``int(...)`` would raise ``ValueError`` and surface as a raw
+    traceback to the requester. Falling back to ``default`` here turns a
+    malformed field into an actionable "insufficient balance" message
+    downstream instead.
+
+    :param value: the value to coerce.
+    :param default: the value to return when ``value`` is None or not coercible.
+    :return: an int.
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class PaymentChallenge:
+    """Typed view of the structured 402 challenge the mech returns.
+
+    Keeping this typed (rather than a bare ``Dict[str, Any]``) means a key
+    typo at a call site is a mypy error rather than a runtime ``KeyError``,
+    and the ``shortfall`` math lives in one place instead of being
+    re-computed at every consumer.
+    """
+
+    required: int
+    current_balance: int
+    pay_to: str
+    asset: str
+    chain_id: int
+    error: str
+
+    @property
+    def shortfall(self) -> int:
+        """The deficit the requester needs to top up. Never negative."""
+        return max(0, self.required - self.current_balance)
 
 
 class MarketplaceService(
@@ -383,41 +440,58 @@ class MarketplaceService(
         :param payment_type: the request's payment type (for the deposit asset).
         :param auto_deposit: whether to auto-deposit + retry once on a 402.
         :return: the (possibly retried) HTTP response.
-        :raises ValueError: on a 402 when auto-deposit is disabled.
+        :raises ValueError: on a 402 when auto-deposit is disabled, or on a
+            second 402 after the auto-deposit retry (the deposit landed but
+            the mech still considers the balance insufficient).
         """
-        response = requests.post(
-            url=url,
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            timeout=OFFCHAIN_HTTP_TIMEOUT,
-        )
+        response = self._do_offchain_post(url, payload)
         if response.status_code == HTTP_PAYMENT_REQUIRED:
             challenge = self._parse_402_challenge(response)
             if not auto_deposit:
                 raise ValueError(
                     "Offchain request requires payment: need "
-                    f"{challenge['required']} (current balance "
-                    f"{challenge['current_balance']}) deposited to "
-                    f"{challenge['pay_to']}. Re-run with auto-deposit enabled or "
-                    f"top up your prepaid balance. ({challenge['error']})"
+                    f"{challenge.required} (current balance "
+                    f"{challenge.current_balance}) deposited to "
+                    f"{challenge.pay_to}. Re-run with auto-deposit enabled or "
+                    f"top up your prepaid balance. ({challenge.error})"
                 )
             self._auto_deposit_for_402(payment_type, challenge)
-            response = requests.post(
-                url=url,
-                data=payload,
-                headers={"Content-Type": "application/json"},
-                timeout=OFFCHAIN_HTTP_TIMEOUT,
-            )
+            response = self._do_offchain_post(url, payload)
+            if response.status_code == HTTP_PAYMENT_REQUIRED:
+                # The deposit tx already confirmed (DepositService waits for
+                # receipt), so silently returning the second 402 would surface
+                # downstream as a generic "Payment Required (HTTP 402)" error
+                # with no hint that funds moved. Raise explicitly so the user
+                # sees how much is still short and which balance tracker holds
+                # the deposit they just paid for.
+                retry = self._parse_402_challenge(response)
+                raise ValueError(
+                    "Auto-deposit did not clear the 402: deposited to "
+                    f"{retry.pay_to} but the mech still requires "
+                    f"{retry.required} (current balance {retry.current_balance}, "
+                    f"remaining shortfall {retry.shortfall}). The deposit may "
+                    f"not be mined yet, the price may have moved, or the asset "
+                    f"may be wrong. ({retry.error})"
+                )
         self._log_payment_receipt(response)
         return response
 
     @staticmethod
-    def _parse_402_challenge(response: requests.Response) -> Dict[str, Any]:
+    def _do_offchain_post(url: str, payload: Dict[str, Any]) -> requests.Response:
+        """POST the offchain payload. Centralises the headers + timeout."""
+        return requests.post(
+            url=url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=OFFCHAIN_HTTP_TIMEOUT,
+        )
+
+    @staticmethod
+    def _parse_402_challenge(response: requests.Response) -> PaymentChallenge:
         """Parse the structured 402 challenge body + WWW-Authenticate header.
 
         :param response: the 402 HTTP response from the mech.
-        :return: the normalised challenge: required, current_balance, pay_to,
-            asset, chain_id, error.
+        :return: the normalised challenge as a typed PaymentChallenge.
         """
         authenticate = response.headers.get("WWW-Authenticate")
         if authenticate:
@@ -425,18 +499,29 @@ class MarketplaceService(
         try:
             body = response.json()
         except ValueError:
+            # A non-JSON 402 body is the mech violating its own response
+            # contract; log enough of it for an operator to debug, but don't
+            # blow up the request. Downstream auto-deposit math degrades to a
+            # zero-shortfall no-op, and the no-auto-deposit error message
+            # surfaces "need 0 ... deposited to ''" which is at least
+            # truthful given the body the mech sent.
+            logger.warning(
+                "402 body was not valid JSON; falling back to defaults. "
+                "Raw body (first 500 chars): %r",
+                response.text[:500],
+            )
             body = {}
-        return {
-            "required": int(body.get("required", 0) or 0),
-            "current_balance": int(body.get("currentBalance", 0) or 0),
-            "pay_to": body.get("payTo", ""),
-            "asset": body.get("asset", ""),
-            "chain_id": int(body.get("chainId", 0) or 0),
-            "error": body.get("error", "payment required"),
-        }
+        return PaymentChallenge(
+            required=_safe_int(body.get("required")),
+            current_balance=_safe_int(body.get("currentBalance")),
+            pay_to=str(body.get("payTo", "")),
+            asset=str(body.get("asset", "")),
+            chain_id=_safe_int(body.get("chainId")),
+            error=str(body.get("error", "payment required")),
+        )
 
     def _auto_deposit_for_402(
-        self, payment_type: PaymentType, challenge: Dict[str, Any]
+        self, payment_type: PaymentType, challenge: PaymentChallenge
     ) -> None:
         """Deposit the 402 shortfall into the prepaid balance.
 
@@ -444,9 +529,12 @@ class MarketplaceService(
         :param challenge: the parsed 402 challenge.
         :raises ValueError: if the payment type doesn't support auto-deposit.
         """
-        shortfall = challenge["required"] - challenge["current_balance"]
-        if shortfall <= 0:
+        if challenge.shortfall <= 0:
             return
+        if payment_type not in _SUPPORTED_DEPOSIT_PAYMENT_TYPES:
+            raise ValueError(
+                f"Auto-deposit is not supported for payment type {payment_type.name}"
+            )
         # Imported here to avoid a circular import at module load.
         from mech_client.services.deposit_service import (  # pylint: disable=import-outside-toplevel
             DepositService,
@@ -459,19 +547,23 @@ class MarketplaceService(
             safe_address=self.safe_address,
             ethereum_client=self.ethereum_client,
         )
-        logger.info(f"Auto-depositing {shortfall} to top up the prepaid balance...")
-        # Explicit per-type dispatch (not is_native/is_token, which group the NVM
-        # subscription types in — those use a subscription, not a balance-tracker
-        # deposit, so auto-deposit doesn't apply to them).
+        logger.info(
+            f"Auto-depositing {challenge.shortfall} to top up the prepaid balance..."
+        )
+        # Per-asset dispatch over the supported-types frozenset. A future
+        # payment type would need to be added to _SUPPORTED_DEPOSIT_PAYMENT_TYPES
+        # AND get a branch here; the assertion-shaped raise below catches the
+        # mismatch if only the set is updated.
         if payment_type == PaymentType.NATIVE:
-            deposit_service.deposit_native(shortfall)
+            deposit_service.deposit_native(challenge.shortfall)
         elif payment_type == PaymentType.OLAS_TOKEN:
-            deposit_service.deposit_token(shortfall, "olas")
+            deposit_service.deposit_token(challenge.shortfall, "olas")
         elif payment_type == PaymentType.USDC_TOKEN:
-            deposit_service.deposit_token(shortfall, "usdc")
-        else:
+            deposit_service.deposit_token(challenge.shortfall, "usdc")
+        else:  # pragma: no cover - guarded by the membership check above
             raise ValueError(
-                f"Auto-deposit is not supported for payment type {payment_type.name}"
+                f"Internal error: {payment_type.name} is listed as supported "
+                f"but has no deposit dispatch branch."
             )
 
     @staticmethod

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -48,6 +48,15 @@ logger = logging.getLogger(__name__)
 HTTP_PAYMENT_REQUIRED = 402
 # Outbound HTTP timeout (seconds) for the offchain request POST.
 OFFCHAIN_HTTP_TIMEOUT = 30
+# Hard cap on auto-deposit: refuse to top up more than this multiple of the
+# requester's signed ``max_delivery_rate`` in a single retry. The mech URL is
+# auto-discovered from on-chain metadata, so without a cap a compromised or
+# buggy mech could return a huge ``required`` and drain the user's wallet
+# into their own balance tracker. Funds aren't stolen (they sit in the user's
+# tracker, bounded by ``check_balance``) but they're locked up and the user's
+# wallet drained. 10x is generous for legitimate price moves between
+# signature and request, tight enough that catastrophic drain stays bounded.
+_MAX_AUTO_DEPOSIT_RATIO = 10
 # Payment types that ``_auto_deposit_for_402`` knows how to top up via the
 # balance tracker. NVM subscription types (``NATIVE_NVM`` / ``TOKEN_NVM_USDC``)
 # are intentionally excluded: they're paid via subscription, not via a
@@ -388,7 +397,7 @@ class MarketplaceService(
             url = f"{mech_offchain_url.rstrip('/')}/send_signed_requests"
             try:
                 response = self._post_offchain_request(
-                    url, payload, payment_type, auto_deposit
+                    url, payload, payment_type, auto_deposit, max_delivery_rate
                 )
                 if not response.ok:
                     reason = ""
@@ -427,22 +436,29 @@ class MarketplaceService(
         payload: Dict[str, Any],
         payment_type: PaymentType,
         auto_deposit: bool,
+        max_delivery_rate: int,
     ) -> requests.Response:
         """POST an offchain request, handling a structured HTTP 402.
 
         On a 402 (insufficient prepaid balance) the mech returns a structured
         challenge. When ``auto_deposit`` is set, the shortfall is deposited and
         the request is retried once; otherwise an actionable error is raised.
+        ``max_delivery_rate`` (the requester's signed per-request maximum) is
+        used as a hard ceiling on the auto-deposit amount so a hostile or
+        buggy mech can't drain the wallet by returning an inflated ``required``.
         A ``Payment-Receipt`` header on the response is logged.
 
         :param url: the mech's ``/send_signed_requests`` endpoint.
         :param payload: the signed request payload.
         :param payment_type: the request's payment type (for the deposit asset).
         :param auto_deposit: whether to auto-deposit + retry once on a 402.
+        :param max_delivery_rate: the requester's signed per-request maximum,
+            used to cap the auto-deposit amount (see ``_MAX_AUTO_DEPOSIT_RATIO``).
         :return: the (possibly retried) HTTP response.
-        :raises ValueError: on a 402 when auto-deposit is disabled, or on a
-            second 402 after the auto-deposit retry (the deposit landed but
-            the mech still considers the balance insufficient).
+        :raises ValueError: on a 402 when auto-deposit is disabled, on a
+            non-positive shortfall that auto-deposit can't act on, on a deposit
+            request that would exceed the safety cap, or on a second 402 after
+            the deposit landed.
         """
         response = self._do_offchain_post(url, payload)
         if response.status_code == HTTP_PAYMENT_REQUIRED:
@@ -455,7 +471,23 @@ class MarketplaceService(
                     f"{challenge.pay_to}. Re-run with auto-deposit enabled or "
                     f"top up your prepaid balance. ({challenge.error})"
                 )
-            self._auto_deposit_for_402(payment_type, challenge)
+            if challenge.shortfall <= 0:
+                # Auto-deposit can't do anything useful here: either the body
+                # was malformed (``_safe_int`` returned 0 for required) or the
+                # mech is reporting current_balance >= required while still
+                # returning 402. Retrying with the same payload won't help
+                # because nothing about the request changes. Surface the
+                # situation honestly instead of running a no-op deposit + retry
+                # that would otherwise hit the second-402 path with a message
+                # claiming a deposit happened.
+                raise ValueError(
+                    "Offchain request rejected with HTTP 402 but the challenge "
+                    f"reports no shortfall (required={challenge.required}, "
+                    f"current balance={challenge.current_balance}). The mech "
+                    f"may be returning a malformed body or a stale balance. "
+                    f"({challenge.error})"
+                )
+            self._auto_deposit_for_402(payment_type, challenge, max_delivery_rate)
             response = self._do_offchain_post(url, payload)
             if response.status_code == HTTP_PAYMENT_REQUIRED:
                 # The deposit tx already confirmed (DepositService waits for
@@ -521,19 +553,44 @@ class MarketplaceService(
         )
 
     def _auto_deposit_for_402(
-        self, payment_type: PaymentType, challenge: PaymentChallenge
+        self,
+        payment_type: PaymentType,
+        challenge: PaymentChallenge,
+        max_delivery_rate: int,
     ) -> None:
         """Deposit the 402 shortfall into the prepaid balance.
 
+        Refuses to deposit when the shortfall exceeds
+        ``_MAX_AUTO_DEPOSIT_RATIO * max_delivery_rate`` — see the constant's
+        docstring for why the cap exists.
+
         :param payment_type: the request's payment type (native vs token).
         :param challenge: the parsed 402 challenge.
-        :raises ValueError: if the payment type doesn't support auto-deposit.
+        :param max_delivery_rate: the requester's signed per-request maximum.
+        :raises ValueError: if the payment type doesn't support auto-deposit,
+            or if the requested deposit would exceed the safety cap.
         """
         if challenge.shortfall <= 0:
             return
         if payment_type not in _SUPPORTED_DEPOSIT_PAYMENT_TYPES:
             raise ValueError(
                 f"Auto-deposit is not supported for payment type {payment_type.name}"
+            )
+        cap = max_delivery_rate * _MAX_AUTO_DEPOSIT_RATIO
+        if challenge.shortfall > cap:
+            # A mech with a hostile or buggy `required` field can otherwise
+            # extract the user's full wallet balance in a single retry. Cap
+            # at a generous multiple of the per-request maximum the user
+            # actually signed; anything beyond that has to be a manual
+            # deposit so the user can see the amount before it leaves their
+            # wallet.
+            raise ValueError(
+                f"Auto-deposit refused: mech demanded a {challenge.shortfall} "
+                f"shortfall which exceeds the safety cap of {cap} "
+                f"({_MAX_AUTO_DEPOSIT_RATIO}x your signed max_delivery_rate of "
+                f"{max_delivery_rate}). If this is legitimate, deposit the "
+                f"amount manually so it leaves your wallet under your direct "
+                f"control."
             )
         # Imported here to avoid a circular import at module load.
         from mech_client.services.deposit_service import (  # pylint: disable=import-outside-toplevel

--- a/tests/unit/infrastructure/test_ipfs_metadata.py
+++ b/tests/unit/infrastructure/test_ipfs_metadata.py
@@ -32,61 +32,36 @@ FAKE_V1_HASH = "bafybeiabc123"
 
 
 class TestFetchIpfsHash:
-    """Tests for fetch_ipfs_hash (offchain — computes hash without uploading)."""
+    """Tests for fetch_ipfs_hash (offchain — computes hash without contacting IPFS)."""
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_returns_tuple_with_three_elements(self, mock_ipfs_cls: MagicMock) -> None:
-        """Test return value is (truncated_hash, full_hash, ipfs_data)."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_returns_tuple_with_three_elements(self) -> None:
+        """Return value is (truncated_hash, full_hash, ipfs_data)."""
         result = fetch_ipfs_hash("my prompt", "my-tool")
 
         assert len(result) == 3
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_truncated_hash_has_0x_prefix(self, mock_ipfs_cls: MagicMock) -> None:
-        """Test truncated hash starts with 0x."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_truncated_hash_has_0x_prefix(self) -> None:
+        """Truncated hash starts with 0x."""
         truncated, _, _ = fetch_ipfs_hash("prompt", "tool")
 
         assert truncated.startswith("0x")
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_truncated_hash_strips_first_9_chars(self, mock_ipfs_cls: MagicMock) -> None:
-        """Test truncated hash is the full hash minus the first 9 chars plus 0x."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_truncated_hash_strips_first_9_chars(self) -> None:
+        """Truncated hash is the full hash minus the first 9 chars plus 0x."""
         truncated, full, _ = fetch_ipfs_hash("prompt", "tool")
 
         assert truncated == "0x" + full[9:]
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_full_hash_is_v1_hex(self, mock_ipfs_cls: MagicMock) -> None:
-        """Test the second element is the full v1 hex hash."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_full_hash_is_v1_hex(self) -> None:
+        """Full hash is the f01... v1 hex form (multibase 'f' + CIDv1 raw bytes)."""
         _, full, _ = fetch_ipfs_hash("prompt", "tool")
 
-        assert full == FAKE_V1_HEX
+        # multibase 'f' + version 01 + dag-pb codec 70 + sha256 (12 20) + 32-byte digest
+        assert full.startswith("f01701220")
+        assert len(full) == 9 + 64  # prefix + 32-byte digest hex
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_ipfs_data_is_valid_json_with_prompt_and_tool(
-        self, mock_ipfs_cls: MagicMock
-    ) -> None:
-        """Test the third element is a JSON string containing prompt and tool."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_ipfs_data_is_valid_json_with_prompt_and_tool(self) -> None:
+        """Third element is a JSON string containing prompt and tool."""
         _, _, ipfs_data = fetch_ipfs_hash("hello world", "openai-gpt-4")
 
         data = json.loads(ipfs_data)
@@ -94,15 +69,8 @@ class TestFetchIpfsHash:
         assert data["tool"] == "openai-gpt-4"
         assert "nonce" in data
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_extra_attributes_included_in_metadata(
-        self, mock_ipfs_cls: MagicMock
-    ) -> None:
-        """Test extra_attributes are merged into the metadata."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
+    def test_extra_attributes_included_in_metadata(self) -> None:
+        """Extra attributes are merged into the metadata."""
         _, _, ipfs_data = fetch_ipfs_hash(
             "prompt", "tool", extra_attributes={"key": "value", "num": 42}
         )
@@ -111,49 +79,37 @@ class TestFetchIpfsHash:
         assert data["key"] == "value"
         assert data["num"] == 42
 
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_upload_called_with_pin_false(self, mock_ipfs_cls: MagicMock) -> None:
-        """Test upload is called with pin=False for offchain requests."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
+    def test_no_ipfs_daemon_contacted(self) -> None:
+        """fetch_ipfs_hash must not instantiate IPFSClient or contact a daemon.
 
-        fetch_ipfs_hash("prompt", "tool")
-
-        mock_client.upload.assert_called_once()
-        _, kwargs = mock_client.upload.call_args
-        assert kwargs.get("pin") is False
-
-    @patch("mech_client.infrastructure.ipfs.metadata.shutil.rmtree")
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_temp_dir_cleaned_up_on_success(
-        self, mock_ipfs_cls: MagicMock, mock_rmtree: MagicMock
-    ) -> None:
-        """Test temp directory is cleaned up even on success."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.return_value = (FAKE_V1_HASH, FAKE_V1_HEX)
-
-        fetch_ipfs_hash("prompt", "tool")
-
-        mock_rmtree.assert_called_once()
-        _, kwargs = mock_rmtree.call_args
-        assert kwargs.get("ignore_errors") is True
-
-    @patch("mech_client.infrastructure.ipfs.metadata.shutil.rmtree")
-    @patch("mech_client.infrastructure.ipfs.metadata.IPFSClient")
-    def test_temp_dir_cleaned_up_on_error(
-        self, mock_ipfs_cls: MagicMock, mock_rmtree: MagicMock
-    ) -> None:
-        """Test temp directory is cleaned up even when upload raises."""
-        mock_client = MagicMock()
-        mock_ipfs_cls.return_value = mock_client
-        mock_client.upload.side_effect = RuntimeError("upload failed")
-
-        with pytest.raises(RuntimeError):
+        This is the core privacy property of the offchain path: the prompt
+        and any extra attributes never leave the requester's process. A
+        regression that re-introduces an IPFS daemon dependency (e.g. by
+        reverting to IPFSClient.upload) would surface here because the mock
+        catches any instantiation.
+        """
+        with patch("mech_client.infrastructure.ipfs.metadata.IPFSClient") as mock_cls:
             fetch_ipfs_hash("prompt", "tool")
+            mock_cls.assert_not_called()
 
-        mock_rmtree.assert_called_once()
+    def test_hash_is_deterministic_for_same_metadata(self) -> None:
+        """Same ipfs_data must produce the same CID across calls."""
+        # The mech recomputes the CID locally from the ipfs_data the client
+        # transmits. Determinism is what lets that recomputation match the
+        # client's signed value. nonce is randomized, so we compare CIDs by
+        # recomputing on the same returned ipfs_data, not by re-running
+        # fetch_ipfs_hash itself.
+        from mech_client.infrastructure.ipfs.local_cid import compute_cidv1
+        import multibase
+        import multicodec
+
+        _, full, ipfs_data = fetch_ipfs_hash("prompt", "tool")
+        cidv1 = compute_cidv1(ipfs_data.encode("utf-8"))
+        cid_bytes = multibase.decode(cidv1)
+        multihash_bytes = multicodec.remove_prefix(cid_bytes)
+        recomputed_full = "f01" + multihash_bytes.hex()
+
+        assert recomputed_full == full
 
 
 class TestPushMetadataToIpfs:

--- a/tests/unit/infrastructure/test_local_cid.py
+++ b/tests/unit/infrastructure/test_local_cid.py
@@ -91,3 +91,21 @@ def test_compute_cidv1_is_deterministic() -> None:
     """Identical input always produces the same CID — no hidden state."""
     content = b'{"different":"payload"}'
     assert compute_cidv1(content) == compute_cidv1(content)
+
+
+def test_varint_rejects_negative_value() -> None:
+    """The varint encoder refuses negative inputs.
+
+    ``compute_cidv1`` only ever calls ``_varint`` with non-negative values
+    (UnixFS type enum, byte-string length, filesize), so this branch is not
+    reachable in normal flow. The guard exists so a future refactor that
+    starts feeding a negative through doesn't silently produce nonsense
+    bytes that downstream sha256 happily hashes.
+    """
+    # pylint: disable=import-private-name
+    from mech_client.infrastructure.ipfs.local_cid import (  # noqa: PLC0415
+        _varint,
+    )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        _varint(-1)

--- a/tests/unit/infrastructure/test_local_cid.py
+++ b/tests/unit/infrastructure/test_local_cid.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the local CID helper.
+
+The fixtures pair each input byte-string with the CID a real ``ipfs add
+--cid-version=1 --raw-leaves=false`` produced on the same input. Two contracts
+ride on this fixture set:
+
+1. **Parity with go-ipfs.** If a future refactor changes the encoding in a way
+   that breaks parity, every fixture fails loudly rather than silently producing
+   CIDs the on-chain commitment side no longer accepts.
+2. **Parity with the mech.** The same (content, CID) pairs appear in the mech's
+   ``packages/valory/skills/task_execution/tests/utils/test_local_cid.py``.
+   The requester signs over the CID; the mech recomputes the CID locally and
+   compares. A drift between the two encoders would break signature
+   verification and reject every request — keeping the fixture pinned and
+   identical on both sides catches that drift in CI on whichever side it
+   appears.
+"""
+
+import pytest
+
+from mech_client.infrastructure.ipfs.local_cid import compute_cidv1
+
+
+# Tuples of (label, content, expected_cid_from_real_ipfs_add).
+# IMPORTANT: this set must stay in sync with the mech's test_local_cid.py
+# fixtures. They lock byte-for-byte parity between the requester-side and
+# mech-side encoders. If you add a row here, add the same row there.
+_FIXTURES = [
+    (
+        "empty",
+        b"",
+        "bafybeif7ztnhq65lumvvtr4ekcwd2ifwgm3awq4zfr3srh462rwyinlb4y",
+    ),
+    (
+        "small_text",
+        b"hello",
+        "bafybeid3weurg3gvyoi7nisadzolomlvoxoppe2sesktnpvdve3256n5tq",
+    ),
+    (
+        "small_json",
+        b'{"requestId":"42","result":"ok"}',
+        "bafybeihjg4w34tu2zmlriemthl24wdynhfx2rpsiflv7wxmb4lsk34etlu",
+    ),
+    (
+        "100k_repeated",
+        b"x" * 100000,
+        "bafybeiay23kics7rguz4kaxxmyz7d6bciozygbi27wllerri6dpqenuifi",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,content,expected",
+    _FIXTURES,
+    ids=[fx[0] for fx in _FIXTURES],
+)
+def test_compute_cidv1_matches_real_ipfs_output(
+    label: str, content: bytes, expected: str
+) -> None:
+    """Local CIDv1 matches ``ipfs add --cid-version=1 --raw-leaves=false`` byte-for-byte."""
+    assert compute_cidv1(content) == expected
+
+
+def test_compute_cidv1_oversize_raises() -> None:
+    """Content beyond the single-block bound fails loudly rather than silently."""
+    oversized = b"a" * (256 * 1024 + 1)
+    with pytest.raises(ValueError, match="exceeds single-block bound"):
+        compute_cidv1(oversized)
+
+
+def test_compute_cidv1_is_deterministic() -> None:
+    """Identical input always produces the same CID — no hidden state."""
+    content = b'{"different":"payload"}'
+    assert compute_cidv1(content) == compute_cidv1(content)

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -1592,6 +1592,7 @@ class TestOffchain402Handling:
             service._auto_deposit_for_402(
                 PaymentType.NATIVE,
                 PaymentChallenge(100, 30, "0xbt", "", 100, "ib"),
+                max_delivery_rate=100,
             )
             mock_ds.return_value.deposit_native.assert_called_once_with(70)
 
@@ -1602,6 +1603,7 @@ class TestOffchain402Handling:
             service._auto_deposit_for_402(
                 PaymentType.USDC_TOKEN,
                 PaymentChallenge(100, 0, "0xbt", "", 100, "ib"),
+                max_delivery_rate=100,
             )
             mock_ds.return_value.deposit_token.assert_called_once_with(100, "usdc")
 
@@ -1612,6 +1614,7 @@ class TestOffchain402Handling:
             service._auto_deposit_for_402(
                 PaymentType.OLAS_TOKEN,
                 PaymentChallenge(50, 10, "0xbt", "", 100, "ib"),
+                max_delivery_rate=100,
             )
             mock_ds.return_value.deposit_token.assert_called_once_with(40, "olas")
 
@@ -1622,6 +1625,7 @@ class TestOffchain402Handling:
             service._auto_deposit_for_402(
                 PaymentType.NATIVE,
                 PaymentChallenge(50, 50, "0xbt", "", 100, "ib"),
+                max_delivery_rate=100,
             )
             mock_ds.assert_not_called()
 
@@ -1633,7 +1637,42 @@ class TestOffchain402Handling:
                 service._auto_deposit_for_402(
                     PaymentType.NATIVE_NVM,
                     PaymentChallenge(100, 0, "0xbt", "", 100, "ib"),
+                    max_delivery_rate=100,
                 )
+
+    def test_auto_deposit_at_exactly_the_cap_proceeds(self) -> None:
+        """A shortfall equal to 10x max_delivery_rate is allowed."""
+        service = _build_offchain_service()
+        # Cap = 10 * max_delivery_rate = 1000; shortfall = 1000 = at cap.
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            service._auto_deposit_for_402(
+                PaymentType.NATIVE,
+                PaymentChallenge(1000, 0, "0xbt", "", 100, "ib"),
+                max_delivery_rate=100,
+            )
+            mock_ds.return_value.deposit_native.assert_called_once_with(1000)
+
+    def test_auto_deposit_above_the_cap_is_refused(self) -> None:
+        """A shortfall above 10x max_delivery_rate is refused with an actionable error.
+
+        Without this cap a compromised or buggy mech could return a huge
+        ``required`` and drain the user's wallet into their own prepaid
+        balance tracker in one retry. The cap closes that hole; the error
+        must name both the requested amount and the cap so the user can
+        decide whether to deposit manually.
+        """
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            with pytest.raises(
+                ValueError, match=r"refused.*1001.*safety cap of 1000"
+            ):
+                # Cap = 10 * 100 = 1000; shortfall = 1001 = above cap.
+                service._auto_deposit_for_402(
+                    PaymentType.NATIVE,
+                    PaymentChallenge(1001, 0, "0xbt", "", 100, "ib"),
+                    max_delivery_rate=100,
+                )
+            mock_ds.return_value.deposit_native.assert_not_called()
 
     def test_post_offchain_request_success_no_402(self) -> None:
         """A direct 200 returns the response (no deposit attempted)."""
@@ -1643,7 +1682,11 @@ class TestOffchain402Handling:
             return_value=_mock_http_response(200, headers={"Payment-Receipt": "r"}),
         ) as mock_post:
             resp = service._post_offchain_request(
-                "http://mech/send_signed_requests", {}, PaymentType.NATIVE, False
+                "http://mech/send_signed_requests",
+                {},
+                PaymentType.NATIVE,
+                False,
+                max_delivery_rate=100,
             )
             assert resp.status_code == 200
             mock_post.assert_called_once()
@@ -1659,7 +1702,11 @@ class TestOffchain402Handling:
         ):
             with pytest.raises(ValueError, match=r"need 100.*0xbt"):
                 service._post_offchain_request(
-                    "http://mech/send_signed_requests", {}, PaymentType.NATIVE, False
+                    "http://mech/send_signed_requests",
+                    {},
+                    PaymentType.NATIVE,
+                    False,
+                    max_delivery_rate=100,
                 )
 
     def test_post_offchain_request_402_auto_deposit_retries(self) -> None:
@@ -1677,11 +1724,79 @@ class TestOffchain402Handling:
             patch("mech_client.services.deposit_service.DepositService") as mock_ds,
         ):
             resp = service._post_offchain_request(
-                "http://mech/send_signed_requests", {}, PaymentType.NATIVE, True
+                "http://mech/send_signed_requests",
+                {},
+                PaymentType.NATIVE,
+                True,
+                max_delivery_rate=100,
             )
             assert resp.status_code == 200
             assert mock_post.call_count == 2
             mock_ds.return_value.deposit_native.assert_called_once_with(100)
+
+    def test_post_offchain_request_zero_shortfall_skips_retry(self) -> None:
+        """A 402 reporting no shortfall raises directly without retry or deposit.
+
+        Without this guard the code would call ``_auto_deposit_for_402`` (which
+        no-ops on ``shortfall <= 0``), then issue a pointless retry POST, and
+        if the retry also 402'd, surface the message claiming "Auto-deposit
+        did not clear the 402: deposited to <pay_to>" — telling the user
+        funds were deposited when none were. The two ways this gets reached
+        in practice are a malformed 402 body (``_safe_int`` zeros out the
+        numeric fields) and a mech bug reporting ``current_balance >=
+        required`` while still 402-ing.
+        """
+        service = _build_offchain_service()
+        with (
+            patch(
+                "mech_client.services.marketplace_service.requests.post",
+                return_value=_mock_http_response(
+                    402,
+                    {"required": "100", "currentBalance": "100", "payTo": "0xbt"},
+                ),
+            ) as mock_post,
+            patch("mech_client.services.deposit_service.DepositService") as mock_ds,
+        ):
+            with pytest.raises(
+                ValueError, match=r"reports no shortfall.*required=100.*balance=100"
+            ) as exc_info:
+                service._post_offchain_request(
+                    "http://mech/send_signed_requests",
+                    {},
+                    PaymentType.NATIVE,
+                    True,
+                    max_delivery_rate=100,
+                )
+        # Exactly one POST: the retry must not fire when no deposit happened.
+        assert mock_post.call_count == 1
+        mock_ds.return_value.deposit_native.assert_not_called()
+        # And the error must not claim funds were deposited.
+        assert "deposited to" not in str(exc_info.value)
+
+    def test_post_offchain_request_above_cap_is_refused(self) -> None:
+        """A 402 demanding more than the safety cap is refused, no retry, no deposit."""
+        service = _build_offchain_service()
+        with (
+            patch(
+                "mech_client.services.marketplace_service.requests.post",
+                return_value=_mock_http_response(
+                    402,
+                    {"required": "10001", "currentBalance": "0", "payTo": "0xbt"},
+                ),
+            ) as mock_post,
+            patch("mech_client.services.deposit_service.DepositService") as mock_ds,
+        ):
+            with pytest.raises(ValueError, match=r"refused.*safety cap"):
+                service._post_offchain_request(
+                    "http://mech/send_signed_requests",
+                    {},
+                    PaymentType.NATIVE,
+                    True,
+                    max_delivery_rate=1000,
+                )
+        # Only the original POST happened — no deposit, no retry.
+        assert mock_post.call_count == 1
+        mock_ds.return_value.deposit_native.assert_not_called()
 
     def test_post_offchain_request_second_402_after_deposit_raises_actionable(
         self,
@@ -1716,7 +1831,11 @@ class TestOffchain402Handling:
                 ValueError, match=r"Auto-deposit did not clear the 402.*0xbt"
             ) as exc_info:
                 service._post_offchain_request(
-                    "http://mech/send_signed_requests", {}, PaymentType.NATIVE, True
+                    "http://mech/send_signed_requests",
+                    {},
+                    PaymentType.NATIVE,
+                    True,
+                    max_delivery_rate=200,
                 )
         assert mock_post.call_count == 2
         # The deposit DID happen; the message has to make that visible.

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -19,6 +19,7 @@
 
 """Tests for marketplace service."""
 
+from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -130,7 +131,6 @@ class TestMarketplaceServiceValidation:
             )
 
 
-
 class TestGetMarketplaceContract:
     """Tests for _get_marketplace_contract method."""
 
@@ -178,7 +178,9 @@ class TestGetMarketplaceContract:
         )
 
         # Get contract
-        contract = service._get_marketplace_contract()  # pylint: disable=protected-access
+        contract = (
+            service._get_marketplace_contract()
+        )  # pylint: disable=protected-access
 
         # Verify
         assert contract == mock_contract
@@ -223,9 +225,13 @@ class TestFetchMechInfo:
         mock_mech_contract = MagicMock()
         # Return NATIVE payment type value as bytes
         payment_type_bytes = bytes.fromhex(PaymentType.NATIVE.value)
-        mock_mech_contract.functions.paymentType.return_value.call.return_value = payment_type_bytes
+        mock_mech_contract.functions.paymentType.return_value.call.return_value = (
+            payment_type_bytes
+        )
         mock_mech_contract.functions.serviceId.return_value.call.return_value = 42
-        mock_mech_contract.functions.maxDeliveryRate.return_value.call.return_value = 10**17
+        mock_mech_contract.functions.maxDeliveryRate.return_value.call.return_value = (
+            10**17
+        )
 
         mock_get_contract.return_value = mock_mech_contract
         mock_executor_factory.create.return_value = MagicMock()
@@ -238,8 +244,10 @@ class TestFetchMechInfo:
         )
 
         # Fetch mech info
-        payment_type, service_id, max_rate = service._fetch_mech_info(  # pylint: disable=protected-access
-            "0x" + "9" * 40
+        payment_type, service_id, max_rate = (
+            service._fetch_mech_info(  # pylint: disable=protected-access
+                "0x" + "9" * 40
+            )
         )
 
         # Verify
@@ -532,7 +540,9 @@ class TestGetMarketplaceContractError:
         mock_mech_config = create_mock_mech_config()
         mock_mech_config.mech_marketplace_contract = None  # Not configured
         mock_config.return_value = mock_mech_config
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         with pytest.raises(ValueError, match="Marketplace contract not available"):
             service._get_marketplace_contract()  # pylint: disable=protected-access
@@ -560,7 +570,9 @@ class TestFetchMechInfoError:
         mock_mech_config = create_mock_mech_config()
         mock_mech_config.priority_mech_address = None  # No default address
         mock_config.return_value = mock_mech_config
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         with pytest.raises(ValueError, match="No mech address specified"):
             service._fetch_mech_info(None)  # pylint: disable=protected-access
@@ -716,7 +728,9 @@ class TestSendRequestNoPriorityMech:
         mock_mech_config = create_mock_mech_config()
         mock_mech_config.priority_mech_address = None  # No default
         mock_config.return_value = mock_mech_config
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         # Patch the internal helpers that run before the priority mech check
         with patch.object(
@@ -778,7 +792,9 @@ class TestSendRequestOnchainFlow:
         mock_executor.get_sender_address.return_value = "0x" + "a" * 40
         mock_executor_factory.create.return_value = mock_executor
 
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         # Patch internal service methods
         mock_contract = MagicMock()
@@ -855,7 +871,9 @@ class TestSendRequestOnchainFlow:
         mock_executor.get_sender_address.return_value = "0x" + "a" * 40
         mock_executor_factory.create.return_value = mock_executor
 
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         # Mock payment strategy with is_token() = True, sufficient balance
         mock_strategy = MagicMock()
@@ -936,7 +954,9 @@ class TestSendRequestOnchainFlow:
         mock_executor.get_sender_address.return_value = "0x" + "a" * 40
         mock_executor_factory.create.return_value = mock_executor
 
-        service = _build_service(mock_mech_config, mock_ledger_api_cls, mock_executor_factory)
+        service = _build_service(
+            mock_mech_config, mock_ledger_api_cls, mock_executor_factory
+        )
 
         # Mock payment strategy with insufficient balance
         mock_strategy = MagicMock()
@@ -946,7 +966,9 @@ class TestSendRequestOnchainFlow:
 
         mock_push_metadata.return_value = ("0x" + "b" * 64, "ipfs://hash")
 
-        with patch.object(service, "_get_marketplace_contract", return_value=MagicMock()):
+        with patch.object(
+            service, "_get_marketplace_contract", return_value=MagicMock()
+        ):
             with patch.object(
                 service,
                 "_fetch_mech_info",
@@ -1021,9 +1043,7 @@ class TestSendRequestOnchainFlow:
                         "_send_marketplace_request",
                         return_value="0xtxhash",
                     ):
-                        with pytest.raises(
-                            ValueError, match="reverted"
-                        ):
+                        with pytest.raises(ValueError, match="reverted"):
                             await service.send_request(
                                 prompts=("hello",),
                                 tools=("some-tool",),
@@ -1042,19 +1062,16 @@ class TestGasEstimationEnabled:
         from pathlib import Path  # pylint: disable=import-outside-toplevel
 
         config_path = (
-            Path(__file__).parents[3]
-            / "mech_client"
-            / "configs"
-            / "mechs.json"
+            Path(__file__).parents[3] / "mech_client" / "configs" / "mechs.json"
         )
         with open(config_path, encoding="utf-8") as f:
             configs = json.load(f)
 
         for chain_name, chain_config in configs.items():
             ledger_config = chain_config.get("ledger_config", {})
-            assert ledger_config.get("is_gas_estimation_enabled") is True, (
-                f"is_gas_estimation_enabled must be true for {chain_name}"
-            )
+            assert (
+                ledger_config.get("is_gas_estimation_enabled") is True
+            ), f"is_gas_estimation_enabled must be true for {chain_name}"
 
 
 class TestSendOffchainRequest:
@@ -1115,7 +1132,9 @@ class TestSendOffchainRequest:
             "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
             return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hello"}'),
         ):
-            with patch("mech_client.services.marketplace_service.requests") as mock_requests:
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
                 mock_response = MagicMock()
                 mock_response.ok = True
                 mock_response.json.return_value = {"status": "ok"}
@@ -1176,15 +1195,21 @@ class TestSendOffchainRequest:
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
-        mock_contract.functions.getRequestId.return_value.call.return_value = b"\x00" * 32
+        mock_contract.functions.getRequestId.return_value.call.return_value = (
+            b"\x00" * 32
+        )
 
         with patch(
             "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
             return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hello"}'),
         ):
-            with patch("mech_client.services.marketplace_service.requests") as mock_requests:
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
                 # Simulate HTTP error
-                mock_requests.exceptions.RequestException = requests.exceptions.RequestException
+                mock_requests.exceptions.RequestException = (
+                    requests.exceptions.RequestException
+                )
                 mock_requests.post.side_effect = requests.exceptions.RequestException(
                     "connection refused"
                 )
@@ -1241,20 +1266,26 @@ class TestSendOffchainRequest:
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
-        mock_contract.functions.getRequestId.return_value.call.return_value = b"\x00" * 32
+        mock_contract.functions.getRequestId.return_value.call.return_value = (
+            b"\x00" * 32
+        )
 
         with patch(
             "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
             return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hello"}'),
         ):
-            with patch("mech_client.services.marketplace_service.requests") as mock_requests:
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
                 mock_response = MagicMock()
                 mock_response.ok = False
                 mock_response.status_code = 400
                 mock_response.reason = "Bad Request"
                 mock_response.json.return_value = {"reason": "invalid signature"}
                 mock_requests.post.return_value = mock_response
-                mock_requests.exceptions.RequestException = requests.exceptions.RequestException
+                mock_requests.exceptions.RequestException = (
+                    requests.exceptions.RequestException
+                )
 
                 with pytest.raises(
                     ValueError, match="Offchain request rejected: invalid signature"
@@ -1310,20 +1341,26 @@ class TestSendOffchainRequest:
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
-        mock_contract.functions.getRequestId.return_value.call.return_value = b"\x00" * 32
+        mock_contract.functions.getRequestId.return_value.call.return_value = (
+            b"\x00" * 32
+        )
 
         with patch(
             "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
             return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hello"}'),
         ):
-            with patch("mech_client.services.marketplace_service.requests") as mock_requests:
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
                 mock_response = MagicMock()
                 mock_response.ok = False
                 mock_response.status_code = 502
                 mock_response.reason = "Bad Gateway"
                 mock_response.json.side_effect = ValueError("No JSON")
                 mock_requests.post.return_value = mock_response
-                mock_requests.exceptions.RequestException = requests.exceptions.RequestException
+                mock_requests.exceptions.RequestException = (
+                    requests.exceptions.RequestException
+                )
 
                 with pytest.raises(
                     ValueError, match="Offchain request rejected: Bad Gateway"
@@ -1382,7 +1419,9 @@ class TestSendRequestOffchainBranch:
             "receipt": None,
         }
 
-        with patch.object(service, "_get_marketplace_contract", return_value=MagicMock()):
+        with patch.object(
+            service, "_get_marketplace_contract", return_value=MagicMock()
+        ):
             with patch.object(
                 service,
                 "_fetch_mech_info",
@@ -1409,3 +1448,179 @@ class TestSendRequestOffchainBranch:
 
         mock_offchain.assert_called_once()
         assert result["tx_hash"] is None
+
+
+def _build_offchain_service() -> MarketplaceService:
+    """Build a MarketplaceService with its heavy init dependencies mocked."""
+    with (
+        patch(
+            "mech_client.services.base_service.get_mech_config",
+            return_value=create_mock_mech_config(),
+        ),
+        patch("mech_client.services.base_service.EthereumApi"),
+        patch("mech_client.services.base_service.ExecutorFactory"),
+        patch("mech_client.services.marketplace_service.EthereumCrypto"),
+        patch("mech_client.services.marketplace_service.ToolManager"),
+        patch("mech_client.services.marketplace_service.IPFSClient"),
+    ):
+        return MarketplaceService(
+            chain_config="gnosis",
+            agent_mode=False,
+            crypto=create_mock_crypto(),
+        )
+
+
+def _mock_http_response(
+    status_code: int,
+    json_body: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> MagicMock:
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.reason = "OK" if resp.ok else "Payment Required"
+    resp.headers = headers or {}
+    resp.json.return_value = json_body if json_body is not None else {}
+    return resp
+
+
+class TestOffchain402Handling:
+    """Tests for the structured offchain 402 challenge handling."""
+
+    def test_parse_402_challenge_full_body(self) -> None:
+        """A full 402 body + WWW-Authenticate header parses to the normalised dict."""
+        resp = _mock_http_response(
+            402,
+            {
+                "required": "100",
+                "currentBalance": "30",
+                "payTo": "0xbalancetracker",
+                "asset": "0x0000000000000000000000000000000000000000",
+                "chainId": 100,
+                "error": "insufficient balance",
+            },
+            {"WWW-Authenticate": 'Payment scheme="erc20-balance-tracker"'},
+        )
+        challenge = MarketplaceService._parse_402_challenge(resp)
+        assert challenge == {
+            "required": 100,
+            "current_balance": 30,
+            "pay_to": "0xbalancetracker",
+            "asset": "0x0000000000000000000000000000000000000000",
+            "chain_id": 100,
+            "error": "insufficient balance",
+        }
+
+    def test_parse_402_challenge_invalid_body_defaults(self) -> None:
+        """A non-JSON 402 body falls back to safe defaults."""
+        resp = MagicMock()
+        resp.headers = {}
+        resp.json.side_effect = ValueError("no json")
+        challenge = MarketplaceService._parse_402_challenge(resp)
+        assert challenge["required"] == 0
+        assert challenge["current_balance"] == 0
+        assert challenge["error"] == "payment required"
+
+    def test_log_payment_receipt_present(self) -> None:
+        """A Payment-Receipt header is logged without error."""
+        resp = _mock_http_response(200, headers={"Payment-Receipt": "abc123"})
+        MarketplaceService._log_payment_receipt(resp)
+
+    def test_log_payment_receipt_absent(self) -> None:
+        """No Payment-Receipt header is a no-op."""
+        resp = _mock_http_response(200, headers={})
+        MarketplaceService._log_payment_receipt(resp)
+
+    def test_auto_deposit_native(self) -> None:
+        """Native payment deposits the shortfall via deposit_native."""
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            service._auto_deposit_for_402(
+                PaymentType.NATIVE, {"required": 100, "current_balance": 30}
+            )
+            mock_ds.return_value.deposit_native.assert_called_once_with(70)
+
+    def test_auto_deposit_token_usdc(self) -> None:
+        """USDC payment deposits via deposit_token with the usdc token type."""
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            service._auto_deposit_for_402(
+                PaymentType.USDC_TOKEN, {"required": 100, "current_balance": 0}
+            )
+            mock_ds.return_value.deposit_token.assert_called_once_with(100, "usdc")
+
+    def test_auto_deposit_token_olas(self) -> None:
+        """OLAS payment deposits via deposit_token with the olas token type."""
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            service._auto_deposit_for_402(
+                PaymentType.OLAS_TOKEN, {"required": 50, "current_balance": 10}
+            )
+            mock_ds.return_value.deposit_token.assert_called_once_with(40, "olas")
+
+    def test_auto_deposit_skips_when_no_shortfall(self) -> None:
+        """No deposit happens when the balance already covers the requirement."""
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
+            service._auto_deposit_for_402(
+                PaymentType.NATIVE, {"required": 50, "current_balance": 50}
+            )
+            mock_ds.assert_not_called()
+
+    def test_auto_deposit_unsupported_type_raises(self) -> None:
+        """NVM payment types can't be topped up via a balance-tracker deposit."""
+        service = _build_offchain_service()
+        with patch("mech_client.services.deposit_service.DepositService"):
+            with pytest.raises(ValueError, match="not supported"):
+                service._auto_deposit_for_402(
+                    PaymentType.NATIVE_NVM, {"required": 100, "current_balance": 0}
+                )
+
+    def test_post_offchain_request_success_no_402(self) -> None:
+        """A direct 200 returns the response (no deposit attempted)."""
+        service = _build_offchain_service()
+        with patch(
+            "mech_client.services.marketplace_service.requests.post",
+            return_value=_mock_http_response(200, headers={"Payment-Receipt": "r"}),
+        ) as mock_post:
+            resp = service._post_offchain_request(
+                "http://mech/send_signed_requests", {}, PaymentType.NATIVE, False
+            )
+            assert resp.status_code == 200
+            mock_post.assert_called_once()
+
+    def test_post_offchain_request_402_without_auto_deposit_raises(self) -> None:
+        """A 402 without auto-deposit raises an actionable error."""
+        service = _build_offchain_service()
+        with patch(
+            "mech_client.services.marketplace_service.requests.post",
+            return_value=_mock_http_response(
+                402, {"required": "100", "currentBalance": "0", "payTo": "0xbt"}
+            ),
+        ):
+            with pytest.raises(ValueError, match="requires payment"):
+                service._post_offchain_request(
+                    "http://mech/send_signed_requests", {}, PaymentType.NATIVE, False
+                )
+
+    def test_post_offchain_request_402_auto_deposit_retries(self) -> None:
+        """A 402 with auto-deposit deposits the shortfall and retries to a 200."""
+        service = _build_offchain_service()
+        responses = [
+            _mock_http_response(402, {"required": "100", "currentBalance": "0"}),
+            _mock_http_response(200, headers={"Payment-Receipt": "r"}),
+        ]
+        with (
+            patch(
+                "mech_client.services.marketplace_service.requests.post",
+                side_effect=responses,
+            ) as mock_post,
+            patch("mech_client.services.deposit_service.DepositService") as mock_ds,
+        ):
+            resp = service._post_offchain_request(
+                "http://mech/send_signed_requests", {}, PaymentType.NATIVE, True
+            )
+            assert resp.status_code == 200
+            assert mock_post.call_count == 2
+            mock_ds.return_value.deposit_native.assert_called_once_with(100)

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -27,7 +27,10 @@ import requests
 
 from mech_client.infrastructure.config import PaymentType
 from mech_client.infrastructure.config.chain_config import LedgerConfig
-from mech_client.services.marketplace_service import MarketplaceService
+from mech_client.services.marketplace_service import (
+    MarketplaceService,
+    PaymentChallenge,
+)
 
 
 def create_mock_mech_config() -> MagicMock:
@@ -1489,7 +1492,7 @@ class TestOffchain402Handling:
     """Tests for the structured offchain 402 challenge handling."""
 
     def test_parse_402_challenge_full_body(self) -> None:
-        """A full 402 body + WWW-Authenticate header parses to the normalised dict."""
+        """A full 402 body + WWW-Authenticate header parses to a typed PaymentChallenge."""
         resp = _mock_http_response(
             402,
             {
@@ -1503,41 +1506,92 @@ class TestOffchain402Handling:
             {"WWW-Authenticate": 'Payment scheme="erc20-balance-tracker"'},
         )
         challenge = MarketplaceService._parse_402_challenge(resp)
-        assert challenge == {
-            "required": 100,
-            "current_balance": 30,
-            "pay_to": "0xbalancetracker",
-            "asset": "0x0000000000000000000000000000000000000000",
-            "chain_id": 100,
-            "error": "insufficient balance",
-        }
+        assert challenge == PaymentChallenge(
+            required=100,
+            current_balance=30,
+            pay_to="0xbalancetracker",
+            asset="0x0000000000000000000000000000000000000000",
+            chain_id=100,
+            error="insufficient balance",
+        )
+        assert challenge.shortfall == 70
 
-    def test_parse_402_challenge_invalid_body_defaults(self) -> None:
-        """A non-JSON 402 body falls back to safe defaults."""
+    def test_parse_402_challenge_invalid_body_defaults_and_warns(self) -> None:
+        """A non-JSON 402 body falls back to safe defaults and logs a warning."""
         resp = MagicMock()
         resp.headers = {}
         resp.json.side_effect = ValueError("no json")
+        resp.text = "<html>500</html>"
+        # mech_client sets propagate=False on its root logger (see
+        # mech_client/utils/logger.py), so caplog can't see these records.
+        # Patch the module logger's warning method directly.
+        with patch(
+            "mech_client.services.marketplace_service.logger.warning"
+        ) as mock_warn:
+            challenge = MarketplaceService._parse_402_challenge(resp)
+        assert challenge.required == 0
+        assert challenge.current_balance == 0
+        assert challenge.error == "payment required"
+        # Operators need a breadcrumb that the mech sent a bad body — silently
+        # zeroing the challenge would mask a mech-side regression. The warning
+        # must carry the format string AND the raw body so it's actionable.
+        mock_warn.assert_called_once()
+        fmt, *args = mock_warn.call_args[0]
+        assert "not valid JSON" in fmt
+        assert "<html>500</html>" in args
+
+    def test_parse_402_challenge_non_numeric_value_is_tolerated(self) -> None:
+        """A 402 body whose numeric fields hold strings doesn't blow up."""
+        # A mech that sends ``"required": "N/A"`` instead of an int would
+        # otherwise surface as an unhandled ValueError. Treat it as zero so
+        # the caller still gets the no-deposit error message rather than a
+        # raw traceback.
+        resp = _mock_http_response(
+            402,
+            {
+                "required": "N/A",
+                "currentBalance": None,
+                "chainId": "not-a-number",
+                "payTo": "0xbt",
+            },
+        )
         challenge = MarketplaceService._parse_402_challenge(resp)
-        assert challenge["required"] == 0
-        assert challenge["current_balance"] == 0
-        assert challenge["error"] == "payment required"
+        assert challenge.required == 0
+        assert challenge.current_balance == 0
+        assert challenge.chain_id == 0
+        assert challenge.pay_to == "0xbt"
 
-    def test_log_payment_receipt_present(self) -> None:
-        """A Payment-Receipt header is logged without error."""
+    def test_log_payment_receipt_present_logs_value(self) -> None:
+        """The Payment-Receipt header value is the audit signal — log it.
+
+        Patches the module logger directly because mech_client sets
+        propagate=False on its root logger, blocking caplog from seeing
+        the records.
+        """
         resp = _mock_http_response(200, headers={"Payment-Receipt": "abc123"})
-        MarketplaceService._log_payment_receipt(resp)
+        with patch(
+            "mech_client.services.marketplace_service.logger.info"
+        ) as mock_info:
+            MarketplaceService._log_payment_receipt(resp)
+        mock_info.assert_called_once()
+        assert "abc123" in mock_info.call_args[0][0]
 
-    def test_log_payment_receipt_absent(self) -> None:
-        """No Payment-Receipt header is a no-op."""
+    def test_log_payment_receipt_absent_emits_no_record(self) -> None:
+        """No Payment-Receipt header means no log line written."""
         resp = _mock_http_response(200, headers={})
-        MarketplaceService._log_payment_receipt(resp)
+        with patch(
+            "mech_client.services.marketplace_service.logger.info"
+        ) as mock_info:
+            MarketplaceService._log_payment_receipt(resp)
+        mock_info.assert_not_called()
 
     def test_auto_deposit_native(self) -> None:
         """Native payment deposits the shortfall via deposit_native."""
         service = _build_offchain_service()
         with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
             service._auto_deposit_for_402(
-                PaymentType.NATIVE, {"required": 100, "current_balance": 30}
+                PaymentType.NATIVE,
+                PaymentChallenge(100, 30, "0xbt", "", 100, "ib"),
             )
             mock_ds.return_value.deposit_native.assert_called_once_with(70)
 
@@ -1546,7 +1600,8 @@ class TestOffchain402Handling:
         service = _build_offchain_service()
         with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
             service._auto_deposit_for_402(
-                PaymentType.USDC_TOKEN, {"required": 100, "current_balance": 0}
+                PaymentType.USDC_TOKEN,
+                PaymentChallenge(100, 0, "0xbt", "", 100, "ib"),
             )
             mock_ds.return_value.deposit_token.assert_called_once_with(100, "usdc")
 
@@ -1555,7 +1610,8 @@ class TestOffchain402Handling:
         service = _build_offchain_service()
         with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
             service._auto_deposit_for_402(
-                PaymentType.OLAS_TOKEN, {"required": 50, "current_balance": 10}
+                PaymentType.OLAS_TOKEN,
+                PaymentChallenge(50, 10, "0xbt", "", 100, "ib"),
             )
             mock_ds.return_value.deposit_token.assert_called_once_with(40, "olas")
 
@@ -1564,7 +1620,8 @@ class TestOffchain402Handling:
         service = _build_offchain_service()
         with patch("mech_client.services.deposit_service.DepositService") as mock_ds:
             service._auto_deposit_for_402(
-                PaymentType.NATIVE, {"required": 50, "current_balance": 50}
+                PaymentType.NATIVE,
+                PaymentChallenge(50, 50, "0xbt", "", 100, "ib"),
             )
             mock_ds.assert_not_called()
 
@@ -1574,7 +1631,8 @@ class TestOffchain402Handling:
         with patch("mech_client.services.deposit_service.DepositService"):
             with pytest.raises(ValueError, match="not supported"):
                 service._auto_deposit_for_402(
-                    PaymentType.NATIVE_NVM, {"required": 100, "current_balance": 0}
+                    PaymentType.NATIVE_NVM,
+                    PaymentChallenge(100, 0, "0xbt", "", 100, "ib"),
                 )
 
     def test_post_offchain_request_success_no_402(self) -> None:
@@ -1591,7 +1649,7 @@ class TestOffchain402Handling:
             mock_post.assert_called_once()
 
     def test_post_offchain_request_402_without_auto_deposit_raises(self) -> None:
-        """A 402 without auto-deposit raises an actionable error."""
+        """A 402 without auto-deposit raises an error naming the amount + payTo."""
         service = _build_offchain_service()
         with patch(
             "mech_client.services.marketplace_service.requests.post",
@@ -1599,7 +1657,7 @@ class TestOffchain402Handling:
                 402, {"required": "100", "currentBalance": "0", "payTo": "0xbt"}
             ),
         ):
-            with pytest.raises(ValueError, match="requires payment"):
+            with pytest.raises(ValueError, match=r"need 100.*0xbt"):
                 service._post_offchain_request(
                     "http://mech/send_signed_requests", {}, PaymentType.NATIVE, False
                 )
@@ -1624,3 +1682,44 @@ class TestOffchain402Handling:
             assert resp.status_code == 200
             assert mock_post.call_count == 2
             mock_ds.return_value.deposit_native.assert_called_once_with(100)
+
+    def test_post_offchain_request_second_402_after_deposit_raises_actionable(
+        self,
+    ) -> None:
+        """A 402 that survives the auto-deposit retry surfaces a deposit-aware error.
+
+        The deposit tx is awaited synchronously (``DepositService`` waits for
+        receipt), so by the time the second POST runs the funds have moved.
+        Silently returning the second 402 here would hit the generic
+        ``Offchain request rejected: Payment Required (HTTP 402)`` branch and
+        hide that fact from the user. The error must name the still-outstanding
+        shortfall and the balance tracker the deposit landed in so they can
+        debug (price moved, deposit too small, tx not mined yet, wrong asset).
+        """
+        service = _build_offchain_service()
+        responses = [
+            _mock_http_response(
+                402, {"required": "100", "currentBalance": "0", "payTo": "0xbt"}
+            ),
+            _mock_http_response(
+                402, {"required": "150", "currentBalance": "100", "payTo": "0xbt"}
+            ),
+        ]
+        with (
+            patch(
+                "mech_client.services.marketplace_service.requests.post",
+                side_effect=responses,
+            ) as mock_post,
+            patch("mech_client.services.deposit_service.DepositService") as mock_ds,
+        ):
+            with pytest.raises(
+                ValueError, match=r"Auto-deposit did not clear the 402.*0xbt"
+            ) as exc_info:
+                service._post_offchain_request(
+                    "http://mech/send_signed_requests", {}, PaymentType.NATIVE, True
+                )
+        assert mock_post.call_count == 2
+        # The deposit DID happen; the message has to make that visible.
+        mock_ds.return_value.deposit_native.assert_called_once()
+        # Surface the still-outstanding shortfall in the message.
+        assert "remaining shortfall 50" in str(exc_info.value)


### PR DESCRIPTION
## WS-2 — mech-client offchain payment handling

Part of the Marketplace/API offchain migration (Thread 1, requester side). Targets the offchain server contract defined in **mech#454** (structured 402 + `Payment-Receipt`).

### Context
The offchain request path already exists on `main`: it skips the IPFS upload, computes the content CID locally, POSTs the signed request to `/send_signed_requests`, and polls `/fetch_offchain_info`. The missing WS-2 piece is the **payment handshake** — today any non-2xx from the mech is collapsed into a generic `"rejected"` error, with no handling of the structured 402 the mech now returns.

### What this adds
- **Parse the structured 402 challenge** (`required` / `currentBalance` / `payTo` / `asset` / `chainId` / `error`) + the `WWW-Authenticate: Payment` header.
- **Without auto-deposit** (default): raise an actionable error telling the requester exactly how much to deposit and where — instead of an opaque rejection.
- **With `--auto-deposit`**: deposit the shortfall into the prepaid balance via `DepositService` (native / OLAS / USDC; NVM subscription types are explicitly unsupported since they don't use a balance-tracker deposit), then retry the request once.
- **Log the `Payment-Receipt`** header returned on a 200.
- New `--auto-deposit` CLI flag (default off), threaded through `send_request`.
- **Bit-for-bit CID parity with the mech** (resolves Benny's flag on mech#454). The previous offchain CID derivation went through `IPFSClient.upload(file, pin=False)`, which still contacts a real IPFS daemon and depends on the daemon's encoding. Replaced with a byte-identical port of the mech's `compute_cidv1` (single-block UnixFS + DAG-PB, bare-file CIDv1, pure Python, no daemon). Pinned with a shared fixture set that mirrors the mech's `test_local_cid.py` — every `(content, CID)` pair was reproduced by running `ipfs add --cid-version=1 --raw-leaves=false` and appears in both repos. A regression that re-introduces the daemon path fails the new `test_no_ipfs_daemon_contacted` test loudly.

### Tests
Full suite green; black-clean. New tests cover 402 parse (full + malformed body), receipt logging (present/absent), auto-deposit (native / usdc / olas / no-shortfall skip / unsupported-type raise), the POST paths (direct 200, 402-no-deposit-raises, 402-auto-deposit-retries-to-200), the CID parity fixtures, and the no-daemon-contacted assertion.

### Notes
- Depends on mech#454's 402 contract; not on it being merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)