### PR TITLE
feat(signing): support external signers via an injectable Signer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,41 @@ You can also use the Mech Client as a library on your Python project.
 
     **Note:** See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for architecture details and more examples.
 
+### Using an external signer (no private key in-process)
+
+If key custody lives outside your process (e.g., a local signer service that only exposes sign/send capabilities over an API), implement the `Signer` protocol and pass it as `signer=` instead of `crypto=`. The raw private key never enters the mech-client process:
+
+```python
+from mech_client import MarketplaceService, Signer
+
+
+class MySigner:
+    """Adapter for an external signer service (satisfies the Signer protocol)."""
+
+    address = "0xYourEOA..."  # the EOA the service signs for
+
+    def send_transaction(self, unsigned_tx: dict) -> str:
+        # Forward to your signer service; it fills nonce/gas if absent,
+        # signs, broadcasts, and returns the tx hash.
+        ...
+
+    def sign_message(self, message: bytes) -> bytes:
+        # Sign the raw 32-byte digest directly (no EIP-191 prefix) and
+        # return the 65-byte signature. See Signer.sign_message docs.
+        ...
+
+
+signer: Signer = MySigner()  # structural typing — no inheritance needed
+
+service = MarketplaceService(
+    chain_config="gnosis",
+    agent_mode=False,  # agent mode (Safe) is supported too
+    signer=signer,
+)
+```
+
+This works for on-chain requests (client and agent mode), deposits (`DepositService`), and offchain prepaid requests. In agent mode the Safe transaction is approved via the pre-validated signature encoding, so only ordinary transaction signing is required from the signer. Passing `crypto=` keeps working unchanged (it wraps the key in the default `LocalSigner`).
+
 You can also use the Mech Client to programmatically fetch tools for marketplace mechs in your Python project, as well as retrieve descriptions and input/output schemas for specific tools given their unique identifier.
 
 1. Set up the private key as specified [above](#set-up-the-private-key). Store the resulting key file (e.g., `ethereum_private_key.txt`) in a convenient and secure location.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -321,6 +321,34 @@ class TransactionExecutor(ABC):
         """Execute a plain native token transfer. Returns tx_hash."""
 ```
 
+#### Signing (`domain/signing/`)
+Abstract who holds the key material:
+- `base.py`: `Signer` protocol (injectable signing interface)
+- `local.py`: `LocalSigner` — default implementation wrapping an in-process private key
+
+**Key Abstractions**:
+```python
+@runtime_checkable
+class Signer(Protocol):
+    @property
+    def address(self) -> str:
+        """The EOA address this signer signs for."""
+
+    def send_transaction(self, unsigned_tx: Dict[str, Any]) -> str:
+        """Sign and broadcast an EOA transaction. Returns tx_hash."""
+
+    def sign_message(self, message: bytes) -> bytes:
+        """Sign a raw 32-byte digest (no EIP-191 prefix). Returns 65-byte signature."""
+```
+
+All signing (client-mode EOA transactions, agent-mode Safe outer transactions,
+offchain request signatures) routes through a `Signer`. Services accept
+`signer=` as an alternative to `crypto=`, so key custody can live in an
+external signer service with no raw private key in the mech-client process.
+In agent mode the SafeTx approval uses the Safe's pre-validated signature
+encoding (valid because the outer `execTransaction` sender is the owner), so
+no ECDSA over the SafeTx hash is needed.
+
 #### Delivery Watchers (`domain/delivery/`)
 Handle response delivery mechanisms:
 - `onchain_watcher.py`: On-chain event watching

--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -20,9 +20,25 @@ Example usage:
     ...     prompts=["What is 2+2?"],
     ...     payment_type=PaymentType.NATIVE,
     ... )
+
+To keep the private key out of the process entirely (e.g. key custody in a
+separate signer service), implement the ``Signer`` protocol and pass it
+instead of ``crypto``:
+
+    >>> from mech_client import MarketplaceService, Signer
+    >>>
+    >>> my_signer: Signer = MySignerImplementation()
+    >>> service = MarketplaceService(
+    ...     chain_config="gnosis",
+    ...     agent_mode=False,
+    ...     signer=my_signer,
+    ... )
 """
 
 __version__ = "v0.21.1"
+
+# Signing
+from mech_client.domain.signing import LocalSigner, Signer
 
 # Domain models
 from mech_client.domain.tools.models import (
@@ -70,6 +86,9 @@ __all__ = [
     # Configuration
     "get_mech_config",
     "PaymentType",
+    # Signing
+    "Signer",
+    "LocalSigner",
     # Domain models
     "ToolInfo",
     "ToolsForMarketplaceMech",

--- a/mech_client/domain/execution/agent_executor.py
+++ b/mech_client/domain/execution/agent_executor.py
@@ -21,8 +21,9 @@
 
 from typing import Any, Dict
 
-from aea_ledger_ethereum import EthereumApi, EthereumCrypto
+from aea_ledger_ethereum import EthereumApi
 from mech_client.domain.execution.base import TransactionExecutor
+from mech_client.domain.signing import Signer
 from mech_client.infrastructure.blockchain.safe_client import SafeClient
 from safe_eth.eth import EthereumClient
 from web3.contract import Contract as Web3Contract
@@ -39,7 +40,7 @@ class AgentExecutor(TransactionExecutor):
     def __init__(
         self,
         ledger_api: EthereumApi,
-        crypto: EthereumCrypto,
+        signer: Signer,
         safe_address: str,
         ethereum_client: EthereumClient,
     ):
@@ -47,11 +48,11 @@ class AgentExecutor(TransactionExecutor):
         Initialize agent executor.
 
         :param ledger_api: Ethereum API for blockchain interactions
-        :param crypto: Ethereum crypto object for signing
+        :param signer: Signer for the Safe owner EOA (signs the outer tx)
         :param safe_address: Address of the Safe multisig wallet
         :param ethereum_client: Ethereum client for Safe operations
         """
-        super().__init__(ledger_api, crypto.private_key)
+        super().__init__(ledger_api, signer)
         self.safe_address = safe_address
         self.ethereum_client = ethereum_client
         self.safe_client = SafeClient(ethereum_client, safe_address)
@@ -96,7 +97,7 @@ class AgentExecutor(TransactionExecutor):
             tx_hash = self.safe_client.send_transaction(
                 to_address=contract.address,
                 tx_data=transaction["data"],
-                signer_private_key=self.private_key,
+                signer=self.signer,
                 value=value,
             )
         except Exception as e:  # pylint: disable=broad-except
@@ -123,7 +124,7 @@ class AgentExecutor(TransactionExecutor):
             tx_hash = self.safe_client.send_transaction(
                 to_address=to_address,
                 tx_data="0x",
-                signer_private_key=self.private_key,
+                signer=self.signer,
                 value=amount,
             )
         except Exception as e:  # pylint: disable=broad-except

--- a/mech_client/domain/execution/base.py
+++ b/mech_client/domain/execution/base.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict
 
 from aea_ledger_ethereum import EthereumApi
+from mech_client.domain.signing import Signer
 from web3.contract import Contract as Web3Contract
 
 
@@ -36,16 +37,16 @@ class TransactionExecutor(ABC):
     def __init__(
         self,
         ledger_api: EthereumApi,
-        private_key: str,
+        signer: Signer,
     ):
         """
         Initialize transaction executor.
 
         :param ledger_api: Ethereum API for blockchain interactions
-        :param private_key: Private key for signing transactions
+        :param signer: Signer for signing and broadcasting transactions
         """
         self.ledger_api = ledger_api
-        self.private_key = private_key
+        self.signer = signer
 
     @abstractmethod
     def execute_transaction(

--- a/mech_client/domain/execution/client_executor.py
+++ b/mech_client/domain/execution/client_executor.py
@@ -21,7 +21,6 @@
 
 from typing import Any, Dict
 
-from aea_ledger_ethereum import EthereumApi, EthereumCrypto
 from mech_client.domain.execution.base import TransactionExecutor
 from web3.contract import Contract as Web3Contract
 
@@ -29,19 +28,10 @@ from web3.contract import Contract as Web3Contract
 class ClientExecutor(TransactionExecutor):
     """Transaction executor for client mode (EOA-based signing).
 
-    In client mode, transactions are signed directly by the user's private key
-    and sent to the network without multisig.
+    In client mode, transactions are built locally and handed to the signer,
+    which signs them with the EOA key (locally or in an external signer
+    service) and broadcasts them without multisig.
     """
-
-    def __init__(self, ledger_api: EthereumApi, crypto: EthereumCrypto):
-        """
-        Initialize client executor.
-
-        :param ledger_api: Ethereum API for blockchain interactions
-        :param crypto: Ethereum crypto object for signing
-        """
-        super().__init__(ledger_api, crypto.private_key)
-        self.crypto = crypto
 
     def execute_transaction(
         self,
@@ -53,10 +43,10 @@ class ClientExecutor(TransactionExecutor):
         """
         Execute a contract transaction in client mode.
 
-        Builds, signs, and sends a transaction using the private key.
+        Builds an unsigned transaction and submits it through the signer.
 
         Propagates exceptions from ``ledger_api`` (``raise_on_try=True``)
-        when build, sign, or send fails.
+        when build fails, and from the signer when sign or send fails.
 
         :param contract: Contract instance to call
         :param method_name: Name of the contract method
@@ -71,12 +61,7 @@ class ClientExecutor(TransactionExecutor):
             tx_args=tx_args,
             raise_on_try=True,
         )
-        signed_transaction = self.crypto.sign_transaction(raw_transaction)
-        transaction_digest = self.ledger_api.send_signed_transaction(
-            signed_transaction,
-            raise_on_try=True,
-        )
-        return transaction_digest
+        return self.signer.send_transaction(raw_transaction)
 
     def execute_transfer(
         self,
@@ -87,8 +72,7 @@ class ClientExecutor(TransactionExecutor):
         """
         Execute a plain native token transfer in client mode.
 
-        Propagates exceptions from ``ledger_api.send_signed_transaction``
-        (``raise_on_try=True``) when send fails.
+        Propagates exceptions from the signer when sign or send fails.
 
         :param to_address: Destination address
         :param amount: Amount to transfer in wei
@@ -96,18 +80,13 @@ class ClientExecutor(TransactionExecutor):
         :return: Transaction hash
         """
         raw_transaction = self.ledger_api.get_transfer_transaction(
-            sender_address=self.crypto.address,
+            sender_address=self.signer.address,
             destination_address=to_address,
             amount=amount,
             tx_fee=gas,
             tx_nonce="0x",
         )
-        signed_transaction = self.crypto.sign_transaction(raw_transaction)
-        transaction_digest = self.ledger_api.send_signed_transaction(
-            signed_transaction,
-            raise_on_try=True,
-        )
-        return transaction_digest
+        return self.signer.send_transaction(raw_transaction)
 
     def get_sender_address(self) -> str:
         """
@@ -115,7 +94,7 @@ class ClientExecutor(TransactionExecutor):
 
         :return: EOA address
         """
-        return self.crypto.address
+        return self.signer.address
 
     def get_nonce(self) -> int:
         """
@@ -123,4 +102,4 @@ class ClientExecutor(TransactionExecutor):
 
         :return: Transaction nonce
         """
-        return self.ledger_api.api.eth.get_transaction_count(self.crypto.address)
+        return self.ledger_api.api.eth.get_transaction_count(self.signer.address)

--- a/mech_client/domain/execution/factory.py
+++ b/mech_client/domain/execution/factory.py
@@ -25,6 +25,7 @@ from aea_ledger_ethereum import EthereumApi, EthereumCrypto
 from mech_client.domain.execution.agent_executor import AgentExecutor
 from mech_client.domain.execution.base import TransactionExecutor
 from mech_client.domain.execution.client_executor import ClientExecutor
+from mech_client.domain.signing import LocalSigner, Signer
 from safe_eth.eth import EthereumClient
 
 
@@ -36,24 +37,35 @@ class ExecutorFactory:  # pylint: disable=too-few-public-methods
     """
 
     @staticmethod
-    def create(
+    def create(  # pylint: disable=too-many-arguments
         agent_mode: bool,
         ledger_api: EthereumApi,
-        crypto: EthereumCrypto,
+        crypto: Optional[EthereumCrypto] = None,
         safe_address: Optional[str] = None,
         ethereum_client: Optional[EthereumClient] = None,
+        signer: Optional[Signer] = None,
     ) -> TransactionExecutor:
         """
         Create transaction executor for given mode.
 
+        Signing goes through ``signer`` when provided; otherwise a
+        ``LocalSigner`` is built around ``crypto``.
+
         :param agent_mode: True for agent mode (Safe), False for client mode (EOA)
         :param ledger_api: Ethereum API for blockchain interactions
-        :param crypto: Ethereum crypto object for signing
+        :param crypto: Ethereum crypto object for signing (alternative to signer)
         :param safe_address: Safe address (required for agent mode)
         :param ethereum_client: Ethereum client (required for agent mode)
+        :param signer: Signer for externalized signing (alternative to crypto)
         :return: Concrete executor instance
-        :raises ValueError: If agent mode but Safe address/client not provided
+        :raises ValueError: If neither crypto nor signer is provided, or if
+            agent mode but Safe address/client not provided
         """
+        if signer is None:
+            if crypto is None:
+                raise ValueError("Either a crypto object or a signer is required")
+            signer = LocalSigner(crypto, ledger_api)
+
         if agent_mode:
             if not safe_address or not ethereum_client:
                 raise ValueError(
@@ -61,9 +73,9 @@ class ExecutorFactory:  # pylint: disable=too-few-public-methods
                 )
             return AgentExecutor(
                 ledger_api,
-                crypto,
+                signer,
                 safe_address,
                 ethereum_client,
             )
 
-        return ClientExecutor(ledger_api, crypto)
+        return ClientExecutor(ledger_api, signer)

--- a/mech_client/domain/payment/factory.py
+++ b/mech_client/domain/payment/factory.py
@@ -19,9 +19,7 @@
 
 """Payment strategy factory."""
 
-from typing import Optional
-
-from aea_ledger_ethereum import EthereumApi, EthereumCrypto
+from aea_ledger_ethereum import EthereumApi
 from mech_client.domain.payment.base import PaymentStrategy
 from mech_client.domain.payment.native import NativePaymentStrategy
 from mech_client.domain.payment.nvm import NVMPaymentStrategy
@@ -41,7 +39,6 @@ class PaymentStrategyFactory:  # pylint: disable=too-few-public-methods
         payment_type: PaymentType,
         ledger_api: EthereumApi,
         chain_id: int,
-        crypto: Optional[EthereumCrypto] = None,
     ) -> PaymentStrategy:
         """
         Create payment strategy for given payment type.
@@ -49,7 +46,6 @@ class PaymentStrategyFactory:  # pylint: disable=too-few-public-methods
         :param payment_type: Type of payment
         :param ledger_api: Ethereum API for blockchain interactions
         :param chain_id: Chain ID (100=Gnosis, 137=Polygon, etc.)
-        :param crypto: Ethereum crypto object for signing (optional)
         :return: Concrete payment strategy instance
         :raises ValueError: If payment type is unknown
         """
@@ -57,7 +53,7 @@ class PaymentStrategyFactory:  # pylint: disable=too-few-public-methods
             return NativePaymentStrategy(ledger_api, payment_type, chain_id)
 
         if payment_type in (PaymentType.OLAS_TOKEN, PaymentType.USDC_TOKEN):
-            return TokenPaymentStrategy(ledger_api, payment_type, chain_id, crypto)
+            return TokenPaymentStrategy(ledger_api, payment_type, chain_id)
 
         if payment_type in (PaymentType.NATIVE_NVM, PaymentType.TOKEN_NVM_USDC):
             return NVMPaymentStrategy(ledger_api, payment_type, chain_id)

--- a/mech_client/domain/payment/token.py
+++ b/mech_client/domain/payment/token.py
@@ -21,7 +21,6 @@
 
 from typing import Optional, TYPE_CHECKING
 
-from aea_ledger_ethereum import EthereumApi, EthereumCrypto
 from mech_client.domain.payment.base import PaymentStrategy
 from mech_client.infrastructure.blockchain.abi_loader import get_abi
 from mech_client.infrastructure.blockchain.contracts import get_contract
@@ -30,7 +29,6 @@ from mech_client.infrastructure.config import (
     CHAIN_TO_PRICE_TOKEN_USDC,
     CHAIN_TO_TOKEN_BALANCE_TRACKER_OLAS,
     CHAIN_TO_TOKEN_BALANCE_TRACKER_USDC,
-    PaymentType,
 )
 from mech_client.utils.validators import ensure_checksummed_address
 
@@ -52,24 +50,6 @@ class TokenPaymentStrategy(PaymentStrategy):
     Token payments require approval before transfer. This strategy handles
     both OLAS and USDC token types.
     """
-
-    def __init__(
-        self,
-        ledger_api: EthereumApi,
-        payment_type: PaymentType,
-        chain_id: int,
-        crypto: Optional[EthereumCrypto] = None,
-    ):
-        """
-        Initialize token payment strategy.
-
-        :param ledger_api: Ethereum API for blockchain interactions
-        :param payment_type: Type of payment (TOKEN or USDC_TOKEN)
-        :param chain_id: Chain ID
-        :param crypto: Ethereum crypto object for signing (optional)
-        """
-        super().__init__(ledger_api, payment_type, chain_id)
-        self.crypto = crypto
 
     def check_balance(
         self,

--- a/mech_client/domain/signing/__init__.py
+++ b/mech_client/domain/signing/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Signing abstractions: injectable Signer protocol and local default."""
+
+from mech_client.domain.signing.base import Signer
+from mech_client.domain.signing.local import LocalSigner
+
+__all__ = [
+    "Signer",
+    "LocalSigner",
+]

--- a/mech_client/domain/signing/base.py
+++ b/mech_client/domain/signing/base.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Signer protocol for externalized transaction and message signing."""
+
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Signer(Protocol):
+    """Protocol for signing EOA transactions and messages.
+
+    Implementations own the key material. mech-client never sees the raw
+    private key: it hands over unsigned transactions (or digests) and gets
+    back transaction hashes (or signatures). This enables setups where key
+    custody lives in a separate signer service (e.g. Pearl BYOA agents) —
+    implement this protocol against that service's API and pass the instance
+    as ``signer=`` to ``MarketplaceService`` / ``DepositService``.
+
+    The default implementation is
+    :class:`~mech_client.domain.signing.LocalSigner`, which wraps a local
+    private key (``EthereumCrypto``) and preserves the historic behavior.
+    """
+
+    @property
+    def address(self) -> str:
+        """The checksummed EOA address this signer signs for."""
+
+    def send_transaction(self, unsigned_tx: Dict[str, Any]) -> str:
+        """Sign and broadcast an EOA transaction; return the tx hash.
+
+        ``unsigned_tx`` is a web3-style transaction dict (``chainId``, ``to``,
+        ``value``, ``data``, and usually ``gas``/fee fields). The
+        implementation must fill ``nonce`` — and any other missing fields such
+        as ``gas`` or gas price — if absent. Returns the transaction hash as a
+        0x-prefixed hex string.
+
+        :param unsigned_tx: Unsigned transaction dict
+        """
+
+    def sign_message(self, message: bytes) -> bytes:
+        """Return a 65-byte ECDSA signature (r ‖ s ‖ v) over ``message``.
+
+        The mech marketplace flow passes the raw 32-byte request-id digest
+        here, and the on-chain verifier recovers it with plain
+        ``ecrecover(digest, v, r, s)`` — i.e. the digest must be signed
+        directly (``eth_account``'s ``unsafe_sign_hash`` semantics), NOT
+        wrapped in an EIP-191 personal-message prefix. ``v`` may be
+        ``{0, 1}`` or ``{27, 28}``; the contract normalizes both.
+
+        :param message: Message bytes to sign (32-byte digest for mech requests)
+        """

--- a/mech_client/domain/signing/local.py
+++ b/mech_client/domain/signing/local.py
@@ -66,7 +66,7 @@ class LocalSigner:
             tx["nonce"] = self.ledger_api.api.eth.get_transaction_count(self.address)
         if "gasPrice" not in tx and "maxFeePerGas" not in tx:
             tx["gasPrice"] = self.ledger_api.api.eth.gas_price
-        if not tx.get("gas"):
+        if tx.get("gas") is None:
             tx["gas"] = self.ledger_api.api.eth.estimate_gas(tx)
         signed_transaction = self.crypto.sign_transaction(tx)
         transaction_digest = self.ledger_api.send_signed_transaction(

--- a/mech_client/domain/signing/local.py
+++ b/mech_client/domain/signing/local.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Local signer wrapping an in-process private key (default implementation)."""
+
+from typing import Any, Dict
+
+from aea_ledger_ethereum import EthereumApi, EthereumCrypto
+
+
+class LocalSigner:
+    """Default :class:`Signer` implementation backed by a local private key.
+
+    Wraps an ``EthereumCrypto`` (raw key in-process) and an ``EthereumApi``
+    (for nonce/gas fill and broadcasting), preserving the historic signing
+    behavior of mech-client.
+    """
+
+    def __init__(self, crypto: EthereumCrypto, ledger_api: EthereumApi):
+        """
+        Initialize local signer.
+
+        :param crypto: Ethereum crypto object holding the private key
+        :param ledger_api: Ethereum API used to fill tx defaults and broadcast
+        """
+        self.crypto = crypto
+        self.ledger_api = ledger_api
+
+    @property
+    def address(self) -> str:
+        """The EOA address of the wrapped key.
+
+        :return: Signer's EOA address
+        """
+        return str(self.crypto.address)
+
+    def send_transaction(self, unsigned_tx: Dict[str, Any]) -> str:
+        """Sign an EOA transaction with the local key and broadcast it.
+
+        Fills ``nonce``, gas price, and ``gas`` from the connected node when
+        absent, then signs and sends via the ledger API (``raise_on_try=True``
+        propagates build/sign/send failures).
+
+        :param unsigned_tx: Unsigned transaction dict
+        :return: Transaction hash (0x-prefixed hex string)
+        """
+        tx = dict(unsigned_tx)
+        tx.setdefault("from", self.address)
+        if tx.get("nonce") is None:
+            tx["nonce"] = self.ledger_api.api.eth.get_transaction_count(self.address)
+        if "gasPrice" not in tx and "maxFeePerGas" not in tx:
+            tx["gasPrice"] = self.ledger_api.api.eth.gas_price
+        if not tx.get("gas"):
+            tx["gas"] = self.ledger_api.api.eth.estimate_gas(tx)
+        signed_transaction = self.crypto.sign_transaction(tx)
+        transaction_digest = self.ledger_api.send_signed_transaction(
+            signed_transaction,
+            raise_on_try=True,
+        )
+        return str(transaction_digest)
+
+    def sign_message(self, message: bytes) -> bytes:
+        """Sign ``message`` with the local key.
+
+        For 32-byte inputs (the mech request-id digest) this signs the digest
+        directly (``unsafe_sign_hash``), matching the marketplace contract's
+        plain ``ecrecover`` verification — see :class:`Signer.sign_message`.
+
+        :param message: Message bytes to sign
+        :return: 65-byte signature (r ‖ s ‖ v)
+        """
+        signature = self.crypto.sign_message(message, is_deprecated_mode=True)
+        return bytes.fromhex(signature.removeprefix("0x"))

--- a/mech_client/infrastructure/blockchain/safe_client.py
+++ b/mech_client/infrastructure/blockchain/safe_client.py
@@ -22,6 +22,7 @@
 from typing import Optional
 
 from hexbytes import HexBytes
+from mech_client.domain.signing import Signer
 from safe_eth.eth import EthereumClient  # pylint:disable=import-error
 from safe_eth.safe import Safe  # pylint:disable=import-error
 from web3.constants import ADDRESS_ZERO
@@ -67,22 +68,54 @@ class SafeClient:
             )
         return self._safe
 
-    def send_transaction(  # pylint: disable=too-many-arguments
+    @staticmethod
+    def build_pre_validated_signature(owner: str) -> bytes:
+        """
+        Encode a pre-validated Safe owner signature.
+
+        Format (Safe contracts): ``r`` = owner address left-padded to 32
+        bytes, ``s`` = 0, ``v`` = 1. The Safe accepts it whenever the outer
+        ``execTransaction`` sender is that owner — no ECDSA over the SafeTx
+        hash is needed, so the private key never has to be in-process.
+
+        :param owner: Safe owner address (0x-prefixed) sending the outer tx
+        :return: 65-byte pre-validated signature
+        :raises ValueError: If ``owner`` is not a valid 20-byte hex address
+        """
+        try:
+            owner_bytes = bytes.fromhex(owner.removeprefix("0x"))
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid Safe owner address from signer: {owner!r} (not hex)"
+            ) from e
+        if len(owner_bytes) != 20:
+            raise ValueError(
+                f"Invalid Safe owner address from signer: {owner!r} "
+                f"(expected 20 bytes, got {len(owner_bytes)})"
+            )
+        return b"\x00" * 12 + owner_bytes + b"\x00" * 32 + b"\x01"
+
+    def send_transaction(
         self,
         to_address: str,
         tx_data: str,
-        signer_private_key: str,
+        signer: Signer,
         value: int = 0,
     ) -> HexBytes:
         """
-        Build, sign, and execute a Safe multisig transaction.
+        Build and execute a Safe multisig transaction via the signer.
+
+        The SafeTx carries a pre-validated signature for the signer's address
+        (which must be a Safe owner), and the outer ``execTransaction`` is
+        built unsigned and submitted through ``signer.send_transaction`` —
+        signing happens wherever the signer keeps its key.
 
         Exceptions from building, signing, or executing the transaction
         propagate to the caller instead of being swallowed.
 
         :param to_address: Destination contract/address
         :param tx_data: Transaction data (hex string starting with 0x)
-        :param signer_private_key: Private key for signing
+        :param signer: Signer for the Safe owner EOA sending the outer tx
         :param value: ETH/native token value to send (in wei)
         :return: Transaction hash
         """
@@ -109,16 +142,29 @@ class SafeClient:
             refund_receiver=ADDRESS_ZERO,
         )
 
-        # Sign and execute; the explicit tx_gas skips the outer
-        # eth_estimateGas, which fails for the same 63/64 reason
-        safe_tx.sign(signer_private_key)
+        # Pre-validated signature: valid because the outer tx sender is
+        # the owner encoded in it.
+        safe_tx.signatures = self.build_pre_validated_signature(signer.address)
+
+        # Size the outer gas from the inner estimate; the explicit gas limit
+        # skips the outer eth_estimateGas, which fails for gas-heavy inner
+        # calls for the same 63/64 reason. The nonce is left for the signer
+        # to fill.
         overhead = max(
             OUTER_TX_GAS_OVERHEAD_FLOOR,
             int(estimated_gas * OUTER_TX_GAS_OVERHEAD_SHARE),
         )
         tx_gas = int(estimated_gas * OUTER_TX_GAS_MULTIPLIER) + overhead
-        tx_hash, _ = safe_tx.execute(signer_private_key, tx_gas=tx_gas)
-        return tx_hash
+        outer_tx = safe_tx.w3_tx.build_transaction(
+            {
+                "from": signer.address,
+                "gas": tx_gas,
+                "gasPrice": self.ethereum_client.w3.eth.gas_price,
+            }
+        )
+
+        tx_hash = signer.send_transaction(outer_tx)
+        return HexBytes(tx_hash)
 
     def get_nonce(self) -> int:
         """

--- a/mech_client/services/base_service.py
+++ b/mech_client/services/base_service.py
@@ -72,8 +72,6 @@ class BaseTransactionService:  # pylint: disable=too-few-public-methods,too-many
 
         self.chain_config = chain_config
         self.agent_mode = agent_mode
-        self.crypto = crypto
-        self.private_key = crypto.private_key if crypto is not None else None
         self.safe_address = safe_address
         self.ethereum_client = ethereum_client
 

--- a/mech_client/services/base_service.py
+++ b/mech_client/services/base_service.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 from aea_ledger_ethereum import EthereumApi, EthereumCrypto
 from mech_client.domain.execution import ExecutorFactory, TransactionExecutor
+from mech_client.domain.signing import LocalSigner, Signer
 from mech_client.infrastructure.config import MechConfig, get_mech_config
 from safe_eth.eth import EthereumClient
 
@@ -36,7 +37,11 @@ class BaseTransactionService:  # pylint: disable=too-few-public-methods,too-many
     - Chain configuration and mech config loading
     - Ethereum API creation from ledger config
     - Transaction executor setup (agent mode or client mode)
-    - Crypto and address management
+    - Signer and address management
+
+    Signing is routed through a :class:`Signer`. Pass ``signer=`` to keep the
+    private key out of the mech-client process (external signer service), or
+    ``crypto=`` to sign locally as before.
 
     Subclasses should call super().__init__() first, then add their own
     specific initialization.
@@ -46,23 +51,29 @@ class BaseTransactionService:  # pylint: disable=too-few-public-methods,too-many
         self,
         chain_config: str,
         agent_mode: bool,
-        crypto: EthereumCrypto,
+        crypto: Optional[EthereumCrypto] = None,
         safe_address: Optional[str] = None,
         ethereum_client: Optional[EthereumClient] = None,
+        signer: Optional[Signer] = None,
     ):
         """
         Initialize base transaction service.
 
         :param chain_config: Chain configuration name (gnosis, base, polygon, optimism)
         :param agent_mode: True for agent mode (Safe), False for client mode (EOA)
-        :param crypto: Ethereum crypto object for signing
+        :param crypto: Ethereum crypto object for local signing (alternative to signer)
         :param safe_address: Safe address (required for agent mode)
         :param ethereum_client: Ethereum client (required for agent mode)
+        :param signer: Signer for externalized signing (alternative to crypto)
+        :raises ValueError: If neither crypto nor signer is provided
         """
+        if crypto is None and signer is None:
+            raise ValueError("Either a crypto object or a signer is required")
+
         self.chain_config = chain_config
         self.agent_mode = agent_mode
         self.crypto = crypto
-        self.private_key = crypto.private_key
+        self.private_key = crypto.private_key if crypto is not None else None
         self.safe_address = safe_address
         self.ethereum_client = ethereum_client
 
@@ -72,11 +83,16 @@ class BaseTransactionService:  # pylint: disable=too-few-public-methods,too-many
         )
         self.ledger_api = EthereumApi(**asdict(self.mech_config.ledger_config))
 
+        # Resolve the signer (injected, or local default around crypto)
+        if signer is None:
+            signer = LocalSigner(crypto, self.ledger_api)
+        self.signer: Signer = signer
+
         # Create executor
         self.executor: TransactionExecutor = ExecutorFactory.create(
             agent_mode=agent_mode,
             ledger_api=self.ledger_api,
-            crypto=crypto,
             safe_address=safe_address,
             ethereum_client=ethereum_client,
+            signer=self.signer,
         )

--- a/mech_client/services/deposit_service.py
+++ b/mech_client/services/deposit_service.py
@@ -136,7 +136,6 @@ class DepositService(
             payment_type=payment_type,
             ledger_api=self.ledger_api,
             chain_id=self.mech_config.ledger_config.chain_id,
-            crypto=self.crypto,
         )
 
         # Check balance

--- a/mech_client/services/deposit_service.py
+++ b/mech_client/services/deposit_service.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 from aea_ledger_ethereum import EthereumCrypto
 from mech_client.domain.payment import PaymentStrategyFactory
+from mech_client.domain.signing import Signer
 from mech_client.infrastructure.blockchain.abi_loader import get_abi
 from mech_client.infrastructure.blockchain.contracts import get_contract
 from mech_client.infrastructure.blockchain.receipt_waiter import wait_for_receipt
@@ -47,18 +48,20 @@ class DepositService(
         self,
         chain_config: str,
         agent_mode: bool,
-        crypto: EthereumCrypto,
+        crypto: Optional[EthereumCrypto] = None,
         safe_address: Optional[str] = None,
         ethereum_client: Optional[EthereumClient] = None,
+        signer: Optional[Signer] = None,
     ):
         """
         Initialize deposit service.
 
         :param chain_config: Chain configuration name (gnosis, base, etc.)
         :param agent_mode: True for agent mode (Safe), False for client mode (EOA)
-        :param crypto: Ethereum crypto object for signing
+        :param crypto: Ethereum crypto object for local signing (alternative to signer)
         :param safe_address: Safe address (required for agent mode)
         :param ethereum_client: Ethereum client (required for agent mode)
+        :param signer: Signer for externalized signing (alternative to crypto)
         """
         super().__init__(
             chain_config=chain_config,
@@ -66,6 +69,7 @@ class DepositService(
             crypto=crypto,
             safe_address=safe_address,
             ethereum_client=ethereum_client,
+            signer=signer,
         )
 
     def deposit_native(self, amount: int) -> str:

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -235,7 +235,6 @@ class MarketplaceService(
             payment_type=payment_type,
             ledger_api=self.ledger_api,
             chain_id=self.mech_config.ledger_config.chain_id,
-            crypto=self.crypto,
         )
 
         # Prepare metadata and upload to IPFS
@@ -636,7 +635,6 @@ class MarketplaceService(
         deposit_service = DepositService(
             chain_config=self.chain_config,
             agent_mode=self.agent_mode,
-            crypto=self.crypto,
             safe_address=self.safe_address,
             ethereum_client=self.ethereum_client,
             signer=self.signer,

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, FrozenSet, List, Optional, Tuple, cast
 
 import requests
 from aea_ledger_ethereum import EthereumCrypto
+from eth_account import Account
 from mech_client.domain.delivery import OffchainDeliveryWatcher, OnchainDeliveryWatcher
 from mech_client.domain.payment import PaymentStrategyFactory
 from mech_client.domain.signing import Signer
@@ -415,7 +416,7 @@ class MarketplaceService(
 
             # Sign the request ID digest (raw ecrecover on-chain, no EIP-191
             # prefix — see Signer.sign_message)
-            signature = "0x" + self.signer.sign_message(request_id_bytes).hex()
+            signature = self._sign_request_digest(request_id_bytes)
 
             # Prepare payload
             payload = {
@@ -464,6 +465,58 @@ class MarketplaceService(
             "delivery_results": results,
             "receipt": None,  # No receipt for offchain requests
         }
+
+    def _sign_request_digest(self, request_id_bytes: bytes) -> str:
+        """Sign the request-id digest via the signer and verify recoverability.
+
+        The marketplace contract validates offchain requests with plain
+        ``ecrecover(digest, v, r, s)``, so the signature must be over the raw
+        32-byte digest — NOT wrapped in an EIP-191 personal-message prefix.
+        External signer services commonly default to EIP-191
+        (``eth_account.Account.sign_message``), which produces a signature
+        that recovers to a *different* address; on-chain that fails silently
+        (the request is treated as coming from an unpaid sender). Recovering
+        locally and comparing against ``signer.address`` turns that
+        misconfiguration into an immediate, actionable error at fire time.
+
+        :param request_id_bytes: the 32-byte request-id digest to sign.
+        :return: 0x-prefixed hex signature, as sent to the mech.
+        :raises ValueError: if the signature has the wrong length or does not
+            recover to the signer's address (e.g. the signer applied EIP-191).
+        """
+        signature = self.signer.sign_message(request_id_bytes)
+        if len(signature) != 65:
+            raise ValueError(
+                f"Signer returned a {len(signature)}-byte signature; expected "
+                f"65 bytes (r ‖ s ‖ v). See Signer.sign_message."
+            )
+        # Local recovery expects v in {27, 28}; the contract accepts {0, 1}
+        # too, so normalize only for the check and send the original bytes.
+        normalized = signature
+        if signature[64] < 27:
+            normalized = signature[:64] + bytes([signature[64] + 27])
+        try:
+            # Raw-hash recovery mirroring the on-chain ecrecover.
+            # protected-access: private-but-stable eth_account API;
+            # no-value-for-parameter: _recover_hash is a combomethod, which
+            # pylint misreads as an unbound instance method.
+            # pylint: disable-next=protected-access,no-value-for-parameter
+            recovered = Account._recover_hash(request_id_bytes, signature=normalized)
+        except Exception as e:
+            raise ValueError(
+                f"Signer returned a signature that cannot be recovered over "
+                f"the request digest (v byte {signature[64]}): {e}. See "
+                f"Signer.sign_message for the expected encoding."
+            ) from e
+        if recovered.lower() != self.signer.address.lower():
+            raise ValueError(
+                f"Signer produced a signature that recovers to {recovered}, "
+                f"not the signer address {self.signer.address}. Most likely "
+                f"the signer applied an EIP-191 personal-message prefix; the "
+                f"marketplace contract requires raw-digest signing (see "
+                f"Signer.sign_message)."
+            )
+        return "0x" + signature.hex()
 
     def _post_offchain_request(
         self,

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -27,6 +27,7 @@ import requests
 from aea_ledger_ethereum import EthereumCrypto
 from mech_client.domain.delivery import OffchainDeliveryWatcher, OnchainDeliveryWatcher
 from mech_client.domain.payment import PaymentStrategyFactory
+from mech_client.domain.signing import Signer
 from mech_client.domain.tools import ToolManager
 from mech_client.infrastructure.blockchain.abi_loader import get_abi
 from mech_client.infrastructure.blockchain.contracts import get_contract
@@ -128,18 +129,20 @@ class MarketplaceService(
         self,
         chain_config: str,
         agent_mode: bool,
-        crypto: EthereumCrypto,
+        crypto: Optional[EthereumCrypto] = None,
         safe_address: Optional[str] = None,
         ethereum_client: Optional[EthereumClient] = None,
+        signer: Optional[Signer] = None,
     ):
         """
         Initialize marketplace service.
 
         :param chain_config: Chain configuration name (gnosis, base, etc.)
         :param agent_mode: True for agent mode (Safe), False for client mode (EOA)
-        :param crypto: Ethereum crypto object for signing
+        :param crypto: Ethereum crypto object for local signing (alternative to signer)
         :param safe_address: Safe address (required for agent mode)
         :param ethereum_client: Ethereum client (required for agent mode)
+        :param signer: Signer for externalized signing (alternative to crypto)
         """
         super().__init__(
             chain_config=chain_config,
@@ -147,6 +150,7 @@ class MarketplaceService(
             crypto=crypto,
             safe_address=safe_address,
             ethereum_client=ethereum_client,
+            signer=signer,
         )
 
         # Create tool manager
@@ -373,7 +377,7 @@ class MarketplaceService(
         logger.info("Sending offchain mech marketplace request...")
 
         # Get current nonce from contract
-        sender = self.crypto.address
+        sender = self.signer.address
         current_nonce = marketplace_contract.functions.mapNonces(sender).call()
 
         # Prepare and send each request
@@ -410,10 +414,9 @@ class MarketplaceService(
             request_id_int = int.from_bytes(request_id_bytes, byteorder="big")
             request_id_hex = request_id_bytes.hex()
 
-            # Sign the request ID
-            signature = self.crypto.sign_message(
-                request_id_bytes, is_deprecated_mode=True
-            )
+            # Sign the request ID digest (raw ecrecover on-chain, no EIP-191
+            # prefix — see Signer.sign_message)
+            signature = "0x" + self.signer.sign_message(request_id_bytes).hex()
 
             # Prepare payload
             payload = {
@@ -636,6 +639,7 @@ class MarketplaceService(
             crypto=self.crypto,
             safe_address=self.safe_address,
             ethereum_client=self.ethereum_client,
+            signer=self.signer,
         )
         logger.info(
             f"Auto-depositing {challenge.shortfall} to top up the prepaid balance..."

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests."""

--- a/tests/unit/domain/test_execution_strategies.py
+++ b/tests/unit/domain/test_execution_strategies.py
@@ -26,19 +26,29 @@ import pytest
 from mech_client.domain.execution.agent_executor import AgentExecutor
 from mech_client.domain.execution.client_executor import ClientExecutor
 from mech_client.domain.execution.factory import ExecutorFactory
+from mech_client.domain.signing import LocalSigner
+
+
+def create_mock_signer(address: str = "0x" + "1" * 40) -> MagicMock:
+    """
+    Create a mock Signer.
+
+    :param address: EOA address the signer reports
+    :return: Mock signer instance
+    """
+    mock_signer = MagicMock()
+    mock_signer.address = address
+    mock_signer.send_transaction.return_value = "0xtxhash"
+    return mock_signer
 
 
 class TestExecutorFactory:
     """Tests for ExecutorFactory."""
 
-    @patch("mech_client.domain.execution.client_executor.EthereumCrypto")
-    def test_create_client_executor(
-        self, mock_crypto: MagicMock, mock_ledger_api: MagicMock
-    ) -> None:
-        """Test factory creates client executor for client mode."""
+    def test_create_client_executor(self, mock_ledger_api: MagicMock) -> None:
+        """Test factory creates client executor wrapping crypto in LocalSigner."""
         mock_crypto_instance = MagicMock()
-        mock_crypto.return_value = mock_crypto_instance
-        
+
         executor = ExecutorFactory.create(
             agent_mode=False,
             ledger_api=mock_ledger_api,
@@ -48,14 +58,42 @@ class TestExecutorFactory:
         )
 
         assert isinstance(executor, ClientExecutor)
-        assert executor.crypto == mock_crypto_instance
+        assert isinstance(executor.signer, LocalSigner)
+        assert executor.signer.crypto == mock_crypto_instance
+
+    def test_create_client_executor_with_signer(
+        self, mock_ledger_api: MagicMock
+    ) -> None:
+        """Test factory uses an injected signer directly (no crypto needed)."""
+        mock_signer = create_mock_signer()
+
+        executor = ExecutorFactory.create(
+            agent_mode=False,
+            ledger_api=mock_ledger_api,
+            signer=mock_signer,
+        )
+
+        assert isinstance(executor, ClientExecutor)
+        assert executor.signer is mock_signer
+
+    def test_create_requires_crypto_or_signer(
+        self, mock_ledger_api: MagicMock
+    ) -> None:
+        """Test factory raises when neither crypto nor signer is provided."""
+        with pytest.raises(
+            ValueError, match="Either a crypto object or a signer is required"
+        ):
+            ExecutorFactory.create(
+                agent_mode=False,
+                ledger_api=mock_ledger_api,
+            )
 
     def test_create_agent_executor(
         self, mock_ledger_api: MagicMock, mock_ethereum_client: MagicMock
     ) -> None:
         """Test factory creates agent executor for agent mode."""
         mock_crypto = MagicMock()
-        
+
         executor = ExecutorFactory.create(
             agent_mode=True,
             ledger_api=mock_ledger_api,
@@ -72,7 +110,7 @@ class TestExecutorFactory:
     ) -> None:
         """Test factory raises error when safe_address missing in agent mode."""
         mock_crypto = MagicMock()
-        
+
         with pytest.raises(
             ValueError, match="Safe address and Ethereum client required"
         ):
@@ -109,14 +147,10 @@ class TestClientExecutorTransfer:
         self, mock_ledger_api: MagicMock
     ) -> None:
         """Test successful native transfer in client mode."""
-        mock_crypto = MagicMock()
-        mock_crypto.address = "0x" + "1" * 40
-        mock_crypto.private_key = "0x" + "a" * 64
-        mock_crypto.sign_transaction.return_value = "0xsigned"
+        mock_signer = create_mock_signer()
         mock_ledger_api.get_transfer_transaction.return_value = {"raw": "tx"}
-        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
 
-        executor = ClientExecutor(mock_ledger_api, mock_crypto)
+        executor = ClientExecutor(mock_ledger_api, mock_signer)
         to_address = "0x" + "2" * 40
         amount = 10**18
         gas = 50000
@@ -125,16 +159,13 @@ class TestClientExecutorTransfer:
 
         assert result == "0xtxhash"
         mock_ledger_api.get_transfer_transaction.assert_called_once_with(
-            sender_address=mock_crypto.address,
+            sender_address=mock_signer.address,
             destination_address=to_address,
             amount=amount,
             tx_fee=gas,
             tx_nonce="0x",
         )
-        mock_crypto.sign_transaction.assert_called_once_with({"raw": "tx"})
-        mock_ledger_api.send_signed_transaction.assert_called_once_with(
-            "0xsigned", raise_on_try=True,
-        )
+        mock_signer.send_transaction.assert_called_once_with({"raw": "tx"})
 
 
 class TestAgentExecutorTransfer:
@@ -148,8 +179,7 @@ class TestAgentExecutorTransfer:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """Test successful native transfer through Safe multisig."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
 
         mock_safe_client = MagicMock()
         mock_tx_hash = MagicMock()
@@ -159,7 +189,7 @@ class TestAgentExecutorTransfer:
 
         safe_address = "0x" + "b" * 40
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, safe_address, mock_ethereum_client
+            mock_ledger_api, mock_signer, safe_address, mock_ethereum_client
         )
 
         to_address = "0x" + "2" * 40
@@ -171,7 +201,7 @@ class TestAgentExecutorTransfer:
         mock_safe_client.send_transaction.assert_called_once_with(
             to_address=to_address,
             tx_data="0x",
-            signer_private_key=mock_crypto.private_key,
+            signer=mock_signer,
             value=amount,
         )
 
@@ -183,8 +213,7 @@ class TestAgentExecutorTransfer:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """Test native transfer failure through Safe raises exception."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
 
         mock_safe_client = MagicMock()
         mock_safe_client.send_transaction.side_effect = Exception(
@@ -194,7 +223,7 @@ class TestAgentExecutorTransfer:
 
         safe_address = "0x" + "b" * 40
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, safe_address, mock_ethereum_client
+            mock_ledger_api, mock_signer, safe_address, mock_ethereum_client
         )
 
         with pytest.raises(
@@ -216,8 +245,7 @@ class TestAgentExecutorTransaction:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """tx_args uses sender_address, but web3 build_transaction expects from."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
         mock_ledger_api._chain_id = 100  # pylint: disable=protected-access
 
         mock_safe_client = MagicMock()
@@ -228,7 +256,7 @@ class TestAgentExecutorTransaction:
         mock_safe_client_cls.return_value = mock_safe_client
 
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, "0x" + "b" * 40, mock_ethereum_client
+            mock_ledger_api, mock_signer, "0x" + "b" * 40, mock_ethereum_client
         )
 
         # Mock contract function build_transaction
@@ -258,14 +286,10 @@ class TestClientExecutorTransaction:
         self, mock_ledger_api: MagicMock
     ) -> None:
         """Test successful contract transaction in client mode."""
-        mock_crypto = MagicMock()
-        mock_crypto.address = "0x" + "1" * 40
-        mock_crypto.private_key = "0x" + "a" * 64
-        mock_crypto.sign_transaction.return_value = "0xsigned"
+        mock_signer = create_mock_signer()
         mock_ledger_api.build_transaction.return_value = {"raw": "tx"}
-        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
 
-        executor = ClientExecutor(mock_ledger_api, mock_crypto)
+        executor = ClientExecutor(mock_ledger_api, mock_signer)
 
         mock_contract = MagicMock()
         sender = "0x" + "1" * 40
@@ -287,41 +311,34 @@ class TestClientExecutorTransaction:
             tx_args=tx_args,
             raise_on_try=True,
         )
-        mock_crypto.sign_transaction.assert_called_once_with({"raw": "tx"})
-        mock_ledger_api.send_signed_transaction.assert_called_once_with(
-            "0xsigned", raise_on_try=True
-        )
+        mock_signer.send_transaction.assert_called_once_with({"raw": "tx"})
 
 
 class TestClientExecutorGetters:
     """Tests for ClientExecutor getter methods."""
 
-    def test_get_sender_address_returns_crypto_address(
+    def test_get_sender_address_returns_signer_address(
         self, mock_ledger_api: MagicMock
     ) -> None:
-        """Test get_sender_address returns the EOA crypto address."""
-        mock_crypto = MagicMock()
-        mock_crypto.address = "0x" + "2" * 40
-        mock_crypto.private_key = "0x" + "a" * 64
+        """Test get_sender_address returns the EOA signer address."""
+        mock_signer = create_mock_signer(address="0x" + "2" * 40)
 
-        executor = ClientExecutor(mock_ledger_api, mock_crypto)
+        executor = ClientExecutor(mock_ledger_api, mock_signer)
 
-        assert executor.get_sender_address() == mock_crypto.address
+        assert executor.get_sender_address() == mock_signer.address
 
     def test_get_nonce_returns_transaction_count(
         self, mock_ledger_api: MagicMock
     ) -> None:
         """Test get_nonce returns the on-chain transaction count."""
-        mock_crypto = MagicMock()
-        mock_crypto.address = "0x" + "3" * 40
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer(address="0x" + "3" * 40)
         mock_ledger_api.api.eth.get_transaction_count.return_value = 5
 
-        executor = ClientExecutor(mock_ledger_api, mock_crypto)
+        executor = ClientExecutor(mock_ledger_api, mock_signer)
 
         assert executor.get_nonce() == 5
         mock_ledger_api.api.eth.get_transaction_count.assert_called_once_with(
-            mock_crypto.address
+            mock_signer.address
         )
 
 
@@ -336,8 +353,7 @@ class TestAgentExecutorTransactionFailure:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """Test execute_transaction surfaces the Safe failure reason."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
         mock_ledger_api._chain_id = 100  # pylint: disable=protected-access
 
         mock_safe_client = MagicMock()
@@ -348,7 +364,7 @@ class TestAgentExecutorTransactionFailure:
         mock_safe_client_cls.return_value = mock_safe_client
 
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, "0x" + "b" * 40, mock_ethereum_client
+            mock_ledger_api, mock_signer, "0x" + "b" * 40, mock_ethereum_client
         )
 
         mock_function = MagicMock()
@@ -380,12 +396,11 @@ class TestAgentExecutorGetters:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """Test get_sender_address returns the Safe multisig address."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
         safe_address = "0x" + "b" * 40
 
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, safe_address, mock_ethereum_client
+            mock_ledger_api, mock_signer, safe_address, mock_ethereum_client
         )
 
         assert executor.get_sender_address() == safe_address
@@ -398,15 +413,14 @@ class TestAgentExecutorGetters:
         mock_ethereum_client: MagicMock,
     ) -> None:
         """Test get_nonce returns the Safe nonce."""
-        mock_crypto = MagicMock()
-        mock_crypto.private_key = "0x" + "a" * 64
+        mock_signer = create_mock_signer()
 
         mock_safe_client = MagicMock()
         mock_safe_client.get_nonce.return_value = 3
         mock_safe_client_cls.return_value = mock_safe_client
 
         executor = AgentExecutor(
-            mock_ledger_api, mock_crypto, "0x" + "b" * 40, mock_ethereum_client
+            mock_ledger_api, mock_signer, "0x" + "b" * 40, mock_ethereum_client
         )
 
         assert executor.get_nonce() == 3

--- a/tests/unit/domain/test_execution_strategies.py
+++ b/tests/unit/domain/test_execution_strategies.py
@@ -28,18 +28,7 @@ from mech_client.domain.execution.client_executor import ClientExecutor
 from mech_client.domain.execution.factory import ExecutorFactory
 from mech_client.domain.signing import LocalSigner
 
-
-def create_mock_signer(address: str = "0x" + "1" * 40) -> MagicMock:
-    """
-    Create a mock Signer.
-
-    :param address: EOA address the signer reports
-    :return: Mock signer instance
-    """
-    mock_signer = MagicMock()
-    mock_signer.address = address
-    mock_signer.send_transaction.return_value = "0xtxhash"
-    return mock_signer
+from tests.unit.helpers import DEFAULT_TX_HASH, create_mock_signer
 
 
 class TestExecutorFactory:
@@ -157,7 +146,7 @@ class TestClientExecutorTransfer:
 
         result = executor.execute_transfer(to_address, amount, gas)
 
-        assert result == "0xtxhash"
+        assert result == DEFAULT_TX_HASH
         mock_ledger_api.get_transfer_transaction.assert_called_once_with(
             sender_address=mock_signer.address,
             destination_address=to_address,
@@ -303,7 +292,7 @@ class TestClientExecutorTransaction:
             tx_args=tx_args,
         )
 
-        assert result == "0xtxhash"
+        assert result == DEFAULT_TX_HASH
         mock_ledger_api.build_transaction.assert_called_once_with(
             contract_instance=mock_contract,
             method_name="request",

--- a/tests/unit/domain/test_signing.py
+++ b/tests/unit/domain/test_signing.py
@@ -19,8 +19,12 @@
 
 """Tests for domain.signing (Signer protocol and LocalSigner)."""
 
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock
+
+from aea_ledger_ethereum import EthereumCrypto
+from eth_account import Account
 
 from mech_client.domain.signing import LocalSigner, Signer
 
@@ -139,6 +143,23 @@ class TestLocalSignerSendTransaction:
         signed_tx = mock_crypto.sign_transaction.call_args[0][0]
         assert "gasPrice" not in signed_tx
 
+    def test_preserves_explicit_zero_gas(self) -> None:
+        """Test an explicit gas=0 is kept, not silently re-estimated."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+        mock_ledger_api = MagicMock()
+        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
+
+        signer = LocalSigner(mock_crypto, mock_ledger_api)
+
+        signer.send_transaction(
+            {"to": "0x" + "b" * 40, "nonce": 1, "gas": 0, "gasPrice": 1}
+        )
+
+        signed_tx = mock_crypto.sign_transaction.call_args[0][0]
+        assert signed_tx["gas"] == 0
+        mock_ledger_api.api.eth.estimate_gas.assert_not_called()
+
     def test_does_not_mutate_input_dict(self) -> None:
         """Test the caller's unsigned tx dict is left untouched."""
         mock_crypto = MagicMock()
@@ -181,3 +202,32 @@ class TestLocalSignerSignMessage:
         signature = signer.sign_message(b"\x11" * 32)
 
         assert signature == b"\xcd" * 65
+
+    def test_real_key_signature_recovers_via_raw_ecrecover(
+        self, tmp_path: Path
+    ) -> None:
+        """Test a real-key signature is a raw digest signature (no EIP-191).
+
+        Everything else in this module mocks ``crypto.sign_message``, so an
+        AEA-side change to ``is_deprecated_mode`` semantics would go
+        unnoticed while the marketplace contract's plain
+        ``ecrecover(digest, v, r, s)`` started rejecting offchain requests.
+        This is the one test exercising the real signing primitive: recovery
+        over the *unprefixed* digest must yield the key's address.
+        """
+        key_file = tmp_path / "key.txt"
+        key_file.write_text("0x" + "1" * 64)  # synthetic test key
+        crypto = EthereumCrypto(private_key_path=str(key_file))
+        signer = LocalSigner(crypto, MagicMock())
+        digest = b"\x11" * 32
+
+        signature = signer.sign_message(digest)
+
+        assert len(signature) == 65
+        # Raw-hash recovery, mirroring the on-chain ecrecover (no EIP-191
+        # prefix). pylint: disable applies to eth_account's private-but-stable
+        # classmethod.
+        recovered = Account._recover_hash(  # pylint: disable=protected-access
+            digest, signature=signature
+        )
+        assert recovered == crypto.address

--- a/tests/unit/domain/test_signing.py
+++ b/tests/unit/domain/test_signing.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for domain.signing (Signer protocol and LocalSigner)."""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+from mech_client.domain.signing import LocalSigner, Signer
+
+
+class TestSignerProtocol:
+    """Tests for the Signer runtime-checkable protocol."""
+
+    def test_local_signer_satisfies_protocol(self) -> None:
+        """Test LocalSigner structurally satisfies Signer."""
+        signer = LocalSigner(MagicMock(), MagicMock())
+
+        assert isinstance(signer, Signer)
+
+    def test_custom_implementation_satisfies_protocol(self) -> None:
+        """Test an external implementation structurally satisfies Signer."""
+
+        class RemoteSigner:
+            """Minimal external signer stub."""
+
+            address = "0x" + "1" * 40
+
+            def send_transaction(self, unsigned_tx: Dict[str, Any]) -> str:
+                """Pretend to sign and broadcast."""
+                return "0x" + "0" * 64
+
+            def sign_message(self, message: bytes) -> bytes:
+                """Pretend to sign a digest."""
+                return b"\x00" * 65
+
+        assert isinstance(RemoteSigner(), Signer)
+
+
+class TestLocalSignerAddress:
+    """Tests for LocalSigner.address."""
+
+    def test_address_returns_crypto_address(self) -> None:
+        """Test address proxies the wrapped crypto address."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+
+        signer = LocalSigner(mock_crypto, MagicMock())
+
+        assert signer.address == "0x" + "a" * 40
+
+
+class TestLocalSignerSendTransaction:
+    """Tests for LocalSigner.send_transaction."""
+
+    def test_sends_prebuilt_transaction_unchanged(self) -> None:
+        """Test a fully built tx is signed and sent without refetching fields."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+        mock_crypto.sign_transaction.return_value = {"signed": True}
+        mock_ledger_api = MagicMock()
+        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
+
+        signer = LocalSigner(mock_crypto, mock_ledger_api)
+        unsigned_tx = {
+            "from": "0x" + "a" * 40,
+            "nonce": 7,
+            "gas": 21000,
+            "gasPrice": 10**9,
+            "to": "0x" + "b" * 40,
+            "value": 1,
+        }
+
+        tx_hash = signer.send_transaction(unsigned_tx)
+
+        assert tx_hash == "0xtxhash"
+        mock_crypto.sign_transaction.assert_called_once_with(unsigned_tx)
+        mock_ledger_api.send_signed_transaction.assert_called_once_with(
+            {"signed": True}, raise_on_try=True
+        )
+        # No node lookups needed when the tx is complete
+        mock_ledger_api.api.eth.get_transaction_count.assert_not_called()
+        mock_ledger_api.api.eth.estimate_gas.assert_not_called()
+
+    def test_fills_missing_fields_from_node(self) -> None:
+        """Test nonce, gas price, and gas are filled when absent."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+        mock_crypto.sign_transaction.return_value = {"signed": True}
+        mock_ledger_api = MagicMock()
+        mock_ledger_api.api.eth.get_transaction_count.return_value = 5
+        mock_ledger_api.api.eth.gas_price = 2 * 10**9
+        mock_ledger_api.api.eth.estimate_gas.return_value = 50000
+        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
+
+        signer = LocalSigner(mock_crypto, mock_ledger_api)
+
+        tx_hash = signer.send_transaction({"to": "0x" + "b" * 40, "value": 1})
+
+        assert tx_hash == "0xtxhash"
+        signed_tx = mock_crypto.sign_transaction.call_args[0][0]
+        assert signed_tx["from"] == "0x" + "a" * 40
+        assert signed_tx["nonce"] == 5
+        assert signed_tx["gasPrice"] == 2 * 10**9
+        assert signed_tx["gas"] == 50000
+        mock_ledger_api.api.eth.get_transaction_count.assert_called_once_with(
+            "0x" + "a" * 40
+        )
+
+    def test_does_not_override_eip1559_fees(self) -> None:
+        """Test gasPrice is not added when maxFeePerGas is present."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+        mock_ledger_api = MagicMock()
+        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
+
+        signer = LocalSigner(mock_crypto, mock_ledger_api)
+
+        signer.send_transaction(
+            {"to": "0x" + "b" * 40, "nonce": 1, "gas": 21000, "maxFeePerGas": 10**9}
+        )
+
+        signed_tx = mock_crypto.sign_transaction.call_args[0][0]
+        assert "gasPrice" not in signed_tx
+
+    def test_does_not_mutate_input_dict(self) -> None:
+        """Test the caller's unsigned tx dict is left untouched."""
+        mock_crypto = MagicMock()
+        mock_crypto.address = "0x" + "a" * 40
+        mock_ledger_api = MagicMock()
+        mock_ledger_api.api.eth.get_transaction_count.return_value = 5
+        mock_ledger_api.send_signed_transaction.return_value = "0xtxhash"
+
+        signer = LocalSigner(mock_crypto, mock_ledger_api)
+        unsigned_tx = {"to": "0x" + "b" * 40, "gas": 21000, "gasPrice": 1}
+
+        signer.send_transaction(unsigned_tx)
+
+        assert unsigned_tx == {"to": "0x" + "b" * 40, "gas": 21000, "gasPrice": 1}
+
+
+class TestLocalSignerSignMessage:
+    """Tests for LocalSigner.sign_message."""
+
+    def test_signs_digest_in_deprecated_mode(self) -> None:
+        """Test sign_message delegates to crypto with is_deprecated_mode."""
+        mock_crypto = MagicMock()
+        mock_crypto.sign_message.return_value = "0x" + "ab" * 65
+        signer = LocalSigner(mock_crypto, MagicMock())
+        digest = b"\x11" * 32
+
+        signature = signer.sign_message(digest)
+
+        assert signature == b"\xab" * 65
+        mock_crypto.sign_message.assert_called_once_with(
+            digest, is_deprecated_mode=True
+        )
+
+    def test_handles_unprefixed_signature(self) -> None:
+        """Test sign_message accepts a signature without 0x prefix."""
+        mock_crypto = MagicMock()
+        mock_crypto.sign_message.return_value = "cd" * 65
+        signer = LocalSigner(mock_crypto, MagicMock())
+
+        signature = signer.sign_message(b"\x11" * 32)
+
+        assert signature == b"\xcd" * 65

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Shared unit-test helpers."""
+
+from unittest.mock import MagicMock
+
+DEFAULT_SIGNER_ADDRESS = "0x" + "1" * 40
+DEFAULT_TX_HASH = "0x" + "ff" * 32
+DEFAULT_SIGNATURE = b"\xab" * 65
+
+
+def create_mock_signer(
+    address: str = DEFAULT_SIGNER_ADDRESS,
+    tx_hash: str = DEFAULT_TX_HASH,
+    signature: bytes = DEFAULT_SIGNATURE,
+) -> MagicMock:
+    """
+    Create a mock Signer.
+
+    :param address: EOA address the signer reports
+    :param tx_hash: Transaction hash send_transaction returns
+    :param signature: Signature bytes sign_message returns
+    :return: Mock signer instance
+    """
+    mock_signer = MagicMock()
+    mock_signer.address = address
+    mock_signer.send_transaction.return_value = tx_hash
+    mock_signer.sign_message.return_value = signature
+    return mock_signer

--- a/tests/unit/infrastructure/test_safe_client.py
+++ b/tests/unit/infrastructure/test_safe_client.py
@@ -86,18 +86,82 @@ class TestSafeClientInitialization:
         assert safe1 == safe2 == mock_safe_instance
 
 
+def create_mock_signer(address: str = "0x" + "ab" * 20) -> MagicMock:
+    """
+    Create a mock Signer.
+
+    :param address: EOA address the signer reports
+    :return: Mock signer instance
+    """
+    mock_signer = MagicMock()
+    mock_signer.address = address
+    mock_signer.send_transaction.return_value = "0x" + "ff" * 32
+    return mock_signer
+
+
+class TestPreValidatedSignature:
+    """Tests for build_pre_validated_signature."""
+
+    def test_encoding_layout(self) -> None:
+        """Test r=owner left-padded, s=0, v=1 layout."""
+        owner = "0x" + "ab" * 20
+
+        signature = SafeClient.build_pre_validated_signature(owner)
+
+        assert len(signature) == 65
+        # r: 12 zero bytes then the 20-byte owner address
+        assert signature[:12] == b"\x00" * 12
+        assert signature[12:32] == bytes.fromhex("ab" * 20)
+        # s: zero
+        assert signature[32:64] == b"\x00" * 32
+        # v: 1 marks a pre-validated signature
+        assert signature[64] == 1
+
+    def test_accepts_unprefixed_address(self) -> None:
+        """Test an address without 0x prefix encodes the same signature."""
+        prefixed = SafeClient.build_pre_validated_signature("0x" + "ab" * 20)
+        unprefixed = SafeClient.build_pre_validated_signature("ab" * 20)
+
+        assert prefixed == unprefixed
+
+    def test_rejects_non_hex_address(self) -> None:
+        """Test a non-hex owner address raises a diagnostic ValueError."""
+        with pytest.raises(ValueError, match="Invalid Safe owner address.*not hex"):
+            SafeClient.build_pre_validated_signature("0xnot-an-address")
+
+    def test_rejects_wrong_length_address(self) -> None:
+        """Test a wrong-length owner address raises a diagnostic ValueError."""
+        with pytest.raises(ValueError, match="expected 20 bytes, got 19"):
+            SafeClient.build_pre_validated_signature("0x" + "ab" * 19)
+
+
 class TestSafeClientSendTransaction:
     """Tests for send_transaction method."""
 
+    @staticmethod
+    def _make_safe_tx() -> MagicMock:
+        """Build a mock SafeTx whose w3_tx echoes the given tx params.
+
+        :return: Mock SafeTx
+        """
+        mock_safe_tx = MagicMock()
+        mock_safe_tx.w3_tx.build_transaction.side_effect = lambda params: {
+            **params,
+            "to": "0x1234567890123456789012345678901234567890",
+            "data": "0xouter",
+        }
+        return mock_safe_tx
+
     @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
     def test_send_transaction_success(self, mock_safe_class: MagicMock) -> None:
-        """Test successful Safe transaction."""
+        """Test successful Safe transaction via pre-validated signature."""
         # Setup mocks
         mock_eth_client = MagicMock()
+        mock_eth_client.w3.eth.gas_price = 2_000_000_000
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
         value = 1000000000000000000
 
         # Mock Safe instance
@@ -108,9 +172,7 @@ class TestSafeClientSendTransaction:
         mock_safe_instance.estimate_tx_gas_with_safe.return_value = 100000
 
         # Mock transaction building
-        mock_safe_tx = MagicMock()
-        expected_tx_hash = HexBytes("0x" + "ff" * 32)
-        mock_safe_tx.execute.return_value = (expected_tx_hash, None)
+        mock_safe_tx = self._make_safe_tx()
         mock_safe_instance.build_multisig_tx.return_value = mock_safe_tx
 
         # Create client and send transaction
@@ -118,7 +180,7 @@ class TestSafeClientSendTransaction:
         tx_hash = client.send_transaction(
             to_address=to_address,
             tx_data=tx_data,
-            signer_private_key=signer_key,
+            signer=signer,
             value=value,
         )
 
@@ -140,19 +202,32 @@ class TestSafeClientSendTransaction:
         # safe_tx_gas=0 forwards all gas to the inner call (EIP-150 63/64 fix)
         assert build_call[1]["safe_tx_gas"] == 0
 
-        # Verify transaction signed and executed with an explicit outer gas
-        # limit derived from the inner-call estimate; for a small estimate
-        # the fixed overhead floor applies
-        mock_safe_tx.sign.assert_called_once_with(signer_key)
+        # Verify pre-validated signature set (no ECDSA over the SafeTx hash)
+        assert mock_safe_tx.signatures == SafeClient.build_pre_validated_signature(
+            signer.address
+        )
+        mock_safe_tx.sign.assert_not_called()
+        mock_safe_tx.execute.assert_not_called()
+
+        # Verify the outer tx was built from the owner with an explicit gas
+        # limit derived from the inner-call estimate (skips the outer
+        # eth_estimateGas); for a small estimate the fixed overhead floor
+        # applies
         expected_tx_gas = (
             int(100000 * OUTER_TX_GAS_MULTIPLIER) + OUTER_TX_GAS_OVERHEAD_FLOOR
         )
-        mock_safe_tx.execute.assert_called_once_with(
-            signer_key, tx_gas=expected_tx_gas
-        )
+        outer_params = mock_safe_tx.w3_tx.build_transaction.call_args[0][0]
+        assert outer_params["from"] == signer.address
+        assert outer_params["gasPrice"] == 2_000_000_000
+        assert outer_params["gas"] == expected_tx_gas
+
+        # Verify the outer tx was submitted via the signer
+        signer.send_transaction.assert_called_once()
+        outer_tx = signer.send_transaction.call_args[0][0]
+        assert outer_tx["gas"] == expected_tx_gas
 
         # Verify hash returned
-        assert tx_hash == expected_tx_hash
+        assert tx_hash == HexBytes("0x" + "ff" * 32)
 
     @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
     def test_send_transaction_large_inner_call_scales_overhead(
@@ -163,7 +238,7 @@ class TestSafeClientSendTransaction:
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
 
         # Inner estimate large enough that 5% exceeds the 250k floor
         large_estimate = 10_000_000
@@ -171,21 +246,16 @@ class TestSafeClientSendTransaction:
         mock_safe_class.return_value = mock_safe_instance
         mock_safe_instance.estimate_tx_gas_with_safe.return_value = large_estimate
 
-        mock_safe_tx = MagicMock()
-        mock_safe_tx.execute.return_value = (HexBytes("0x" + "ff" * 32), None)
-        mock_safe_instance.build_multisig_tx.return_value = mock_safe_tx
+        mock_safe_instance.build_multisig_tx.return_value = self._make_safe_tx()
 
         client = SafeClient(mock_eth_client, safe_address)
-        client.send_transaction(
-            to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
-        )
+        client.send_transaction(to_address=to_address, tx_data=tx_data, signer=signer)
 
         expected_tx_gas = int(large_estimate * OUTER_TX_GAS_MULTIPLIER) + int(
             large_estimate * OUTER_TX_GAS_OVERHEAD_SHARE
         )
-        mock_safe_tx.execute.assert_called_once_with(
-            signer_key, tx_gas=expected_tx_gas
-        )
+        outer_tx = signer.send_transaction.call_args[0][0]
+        assert outer_tx["gas"] == expected_tx_gas
 
     @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
     def test_send_transaction_with_zero_value(
@@ -197,7 +267,7 @@ class TestSafeClientSendTransaction:
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
 
         # Mock Safe instance
         mock_safe_instance = MagicMock()
@@ -205,14 +275,12 @@ class TestSafeClientSendTransaction:
         mock_safe_instance.estimate_tx_gas_with_safe.return_value = 100000
 
         # Mock transaction
-        mock_safe_tx = MagicMock()
-        mock_safe_tx.execute.return_value = (HexBytes("0x" + "ff" * 32), None)
-        mock_safe_instance.build_multisig_tx.return_value = mock_safe_tx
+        mock_safe_instance.build_multisig_tx.return_value = self._make_safe_tx()
 
         # Send transaction without value parameter (defaults to 0)
         client = SafeClient(mock_eth_client, safe_address)
         tx_hash = client.send_transaction(
-            to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
+            to_address=to_address, tx_data=tx_data, signer=signer
         )
 
         # Verify value=0 used
@@ -230,7 +298,7 @@ class TestSafeClientSendTransaction:
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
 
         # Mock Safe instance with gas estimation failure
         mock_safe_instance = MagicMock()
@@ -243,7 +311,7 @@ class TestSafeClientSendTransaction:
         client = SafeClient(mock_eth_client, safe_address)
         with pytest.raises(Exception, match="Gas estimation failed"):
             client.send_transaction(
-                to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
+                to_address=to_address, tx_data=tx_data, signer=signer
             )
 
     @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
@@ -254,7 +322,7 @@ class TestSafeClientSendTransaction:
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
 
         # Mock Safe instance
         mock_safe_instance = MagicMock()
@@ -268,63 +336,64 @@ class TestSafeClientSendTransaction:
         client = SafeClient(mock_eth_client, safe_address)
         with pytest.raises(Exception, match="Build transaction failed"):
             client.send_transaction(
-                to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
+                to_address=to_address, tx_data=tx_data, signer=signer
             )
 
     @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
-    def test_send_transaction_sign_failure(self, mock_safe_class: MagicMock) -> None:
-        """Test send_transaction handles signing errors."""
-        # Setup mocks
-        mock_eth_client = MagicMock()
-        safe_address = "0x1234567890123456789012345678901234567890"
-        to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
-        tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
-
-        # Mock Safe instance
-        mock_safe_instance = MagicMock()
-        mock_safe_class.return_value = mock_safe_instance
-        mock_safe_instance.estimate_tx_gas_with_safe.return_value = 100000
-
-        # Mock transaction with sign failure
-        mock_safe_tx = MagicMock()
-        mock_safe_tx.sign.side_effect = Exception("Invalid private key")
-        mock_safe_instance.build_multisig_tx.return_value = mock_safe_tx
-
-        # Send transaction and verify the error is surfaced
-        client = SafeClient(mock_eth_client, safe_address)
-        with pytest.raises(Exception, match="Invalid private key"):
-            client.send_transaction(
-                to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
-            )
-
-    @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
-    def test_send_transaction_execute_failure(
+    def test_send_transaction_outer_build_failure(
         self, mock_safe_class: MagicMock
     ) -> None:
-        """Test send_transaction handles execution errors."""
+        """Test send_transaction handles outer execTransaction build errors."""
         # Setup mocks
         mock_eth_client = MagicMock()
         safe_address = "0x1234567890123456789012345678901234567890"
         to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
         tx_data = "0x1234abcd"
-        signer_key = "0xdeadbeef"
+        signer = create_mock_signer()
 
         # Mock Safe instance
         mock_safe_instance = MagicMock()
         mock_safe_class.return_value = mock_safe_instance
         mock_safe_instance.estimate_tx_gas_with_safe.return_value = 100000
 
-        # Mock transaction with execute failure
+        # Mock outer tx build failure (e.g. estimation revert)
         mock_safe_tx = MagicMock()
-        mock_safe_tx.execute.side_effect = Exception("Execution reverted")
+        mock_safe_tx.w3_tx.build_transaction.side_effect = Exception(
+            "Invalid owner provided"
+        )
         mock_safe_instance.build_multisig_tx.return_value = mock_safe_tx
 
         # Send transaction and verify the error is surfaced
         client = SafeClient(mock_eth_client, safe_address)
-        with pytest.raises(Exception, match="Execution reverted"):
+        with pytest.raises(Exception, match="Invalid owner provided"):
             client.send_transaction(
-                to_address=to_address, tx_data=tx_data, signer_private_key=signer_key
+                to_address=to_address, tx_data=tx_data, signer=signer
+            )
+
+    @patch("mech_client.infrastructure.blockchain.safe_client.Safe")
+    def test_send_transaction_signer_failure(
+        self, mock_safe_class: MagicMock
+    ) -> None:
+        """Test send_transaction surfaces signer submission errors."""
+        # Setup mocks
+        mock_eth_client = MagicMock()
+        safe_address = "0x1234567890123456789012345678901234567890"
+        to_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        tx_data = "0x1234abcd"
+        signer = create_mock_signer()
+        signer.send_transaction.side_effect = Exception("Signer unavailable")
+
+        # Mock Safe instance
+        mock_safe_instance = MagicMock()
+        mock_safe_class.return_value = mock_safe_instance
+        mock_safe_instance.estimate_tx_gas_with_safe.return_value = 100000
+        mock_safe_instance.build_multisig_tx.return_value = self._make_safe_tx()
+
+        # Send transaction and verify the error is surfaced
+        client = SafeClient(mock_eth_client, safe_address)
+        with pytest.raises(Exception, match="Signer unavailable"):
+            client.send_transaction(
+                to_address=to_address, tx_data=tx_data, signer=signer
             )
 
 

--- a/tests/unit/infrastructure/test_safe_client.py
+++ b/tests/unit/infrastructure/test_safe_client.py
@@ -31,6 +31,8 @@ from mech_client.infrastructure.blockchain.safe_client import (
     SafeClient,
 )
 
+from tests.unit.helpers import create_mock_signer
+
 
 class TestSafeClientInitialization:
     """Tests for SafeClient initialization."""
@@ -84,19 +86,6 @@ class TestSafeClientInitialization:
         # Safe constructor only called once
         mock_safe_class.assert_called_once()
         assert safe1 == safe2 == mock_safe_instance
-
-
-def create_mock_signer(address: str = "0x" + "ab" * 20) -> MagicMock:
-    """
-    Create a mock Signer.
-
-    :param address: EOA address the signer reports
-    :return: Mock signer instance
-    """
-    mock_signer = MagicMock()
-    mock_signer.address = address
-    mock_signer.send_transaction.return_value = "0x" + "ff" * 32
-    return mock_signer
 
 
 class TestPreValidatedSignature:

--- a/tests/unit/services/test_deposit_service.py
+++ b/tests/unit/services/test_deposit_service.py
@@ -19,10 +19,11 @@
 
 """Tests for deposit service."""
 
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from mech_client.domain.signing import LocalSigner
 from mech_client.infrastructure.config import PaymentType
 from mech_client.infrastructure.config.chain_config import LedgerConfig
 from mech_client.services.deposit_service import DepositService
@@ -89,7 +90,9 @@ class TestDepositServiceInitialization:
         # Verify initialization
         assert service.chain_config == "gnosis"
         assert service.agent_mode is False
-        assert service.private_key == "0x" + "1" * 64
+        # crypto is wrapped in the default LocalSigner, not stored on the service
+        assert isinstance(service.signer, LocalSigner)
+        assert service.signer.crypto is mock_crypto
         assert service.safe_address is None
         assert service.ethereum_client is None
         mock_config.assert_called_once_with("gnosis", agent_mode=False)
@@ -293,7 +296,6 @@ class TestDepositToken:
             payment_type=PaymentType.OLAS_TOKEN,
             ledger_api=mock_ledger_api,
             chain_id=mock_config.return_value.ledger_config.chain_id,
-            crypto=ANY,
         )
         mock_payment_strategy.check_balance.assert_called_once()
         mock_payment_strategy.approve_if_needed.assert_called_once()
@@ -360,7 +362,6 @@ class TestDepositToken:
             payment_type=PaymentType.USDC_TOKEN,
             ledger_api=mock_ledger_api,
             chain_id=mock_config.return_value.ledger_config.chain_id,
-            crypto=ANY,
         )
         # Approval should have been executed
         assert mock_wait_receipt.call_count == 2  # Once for approval, once for deposit

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -109,6 +109,53 @@ class TestMarketplaceServiceInitialization:
         mock_tool_manager.assert_called_once_with("gnosis")
         mock_ipfs_client.assert_called_once()
 
+    @patch("mech_client.services.marketplace_service.IPFSClient")
+    @patch("mech_client.services.marketplace_service.ToolManager")
+    @patch("mech_client.services.base_service.ExecutorFactory")
+    @patch("mech_client.services.base_service.EthereumApi")
+    @patch("mech_client.services.base_service.get_mech_config")
+    def test_initialization_with_signer_only(
+        self,
+        mock_config: MagicMock,
+        mock_ledger_api: MagicMock,
+        mock_executor_factory: MagicMock,
+        mock_tool_manager: MagicMock,
+        mock_ipfs_client: MagicMock,
+    ) -> None:
+        """Test initialization with an injected signer and no private key."""
+        mock_config.return_value = create_mock_mech_config()
+        mock_executor_factory.create.return_value = MagicMock()
+        mock_signer = MagicMock()
+        mock_signer.address = "0x" + "a" * 40
+
+        service = MarketplaceService(
+            chain_config="gnosis",
+            agent_mode=False,
+            signer=mock_signer,
+        )
+
+        # No key material in-process; signing goes through the signer
+        assert service.crypto is None
+        assert service.private_key is None
+        assert service.signer is mock_signer
+        create_kwargs = mock_executor_factory.create.call_args[1]
+        assert create_kwargs["signer"] is mock_signer
+
+    @patch("mech_client.services.base_service.get_mech_config")
+    def test_initialization_requires_crypto_or_signer(
+        self,
+        mock_config: MagicMock,
+    ) -> None:
+        """Test initialization raises when neither crypto nor signer is given."""
+        with pytest.raises(
+            ValueError, match="Either a crypto object or a signer is required"
+        ):
+            MarketplaceService(
+                chain_config="gnosis",
+                agent_mode=False,
+            )
+        mock_config.assert_not_called()
+
 
 class TestMarketplaceServiceValidation:
     """Tests for input validation in marketplace service."""
@@ -1381,9 +1428,9 @@ class TestSendOffchainRequest:
         )
 
         # Mock crypto address and signing
-        service.crypto = MagicMock()
-        service.crypto.address = "0x" + "a" * 40
-        service.crypto.sign_message.return_value = "0xsignature"
+        service.signer = MagicMock()
+        service.signer.address = "0x" + "a" * 40
+        service.signer.sign_message.return_value = b"\xab" * 65
 
         # Mock marketplace contract
         mock_contract = MagicMock()
@@ -1460,9 +1507,9 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.crypto = MagicMock()
-        service.crypto.address = "0x" + "a" * 40
-        service.crypto.sign_message.return_value = "0xsignature"
+        service.signer = MagicMock()
+        service.signer.address = "0x" + "a" * 40
+        service.signer.sign_message.return_value = b"\xab" * 65
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1531,9 +1578,9 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.crypto = MagicMock()
-        service.crypto.address = "0x" + "a" * 40
-        service.crypto.sign_message.return_value = "0xsignature"
+        service.signer = MagicMock()
+        service.signer.address = "0x" + "a" * 40
+        service.signer.sign_message.return_value = b"\xab" * 65
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1606,9 +1653,9 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.crypto = MagicMock()
-        service.crypto.address = "0x" + "a" * 40
-        service.crypto.sign_message.return_value = "0xsignature"
+        service.signer = MagicMock()
+        service.signer.address = "0x" + "a" * 40
+        service.signer.sign_message.return_value = b"\xab" * 65
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -25,12 +25,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import requests
 
+from mech_client.domain.signing import LocalSigner
 from mech_client.infrastructure.config import PaymentType
 from mech_client.infrastructure.config.chain_config import LedgerConfig
 from mech_client.services.marketplace_service import (
     MarketplaceService,
     PaymentChallenge,
 )
+
+from tests.unit.helpers import create_mock_signer
 
 
 def create_mock_mech_config() -> MagicMock:
@@ -92,16 +95,19 @@ class TestMarketplaceServiceInitialization:
         mock_executor_factory.create.return_value = mock_executor
 
         # Initialize service
+        mock_crypto = create_mock_crypto()
         service = MarketplaceService(
             chain_config="gnosis",
             agent_mode=False,
-            crypto=create_mock_crypto(),
+            crypto=mock_crypto,
         )
 
         # Verify initialization
         assert service.chain_config == "gnosis"
         assert service.agent_mode is False
-        assert service.private_key == "0x" + "1" * 64
+        # crypto is wrapped in the default LocalSigner, not stored on the service
+        assert isinstance(service.signer, LocalSigner)
+        assert service.signer.crypto is mock_crypto
         assert service.safe_address is None
         assert service.ethereum_client is None
         mock_config.assert_called_once_with("gnosis", agent_mode=False)
@@ -135,8 +141,6 @@ class TestMarketplaceServiceInitialization:
         )
 
         # No key material in-process; signing goes through the signer
-        assert service.crypto is None
-        assert service.private_key is None
         assert service.signer is mock_signer
         create_kwargs = mock_executor_factory.create.call_args[1]
         assert create_kwargs["signer"] is mock_signer
@@ -1428,9 +1432,7 @@ class TestSendOffchainRequest:
         )
 
         # Mock crypto address and signing
-        service.signer = MagicMock()
-        service.signer.address = "0x" + "a" * 40
-        service.signer.sign_message.return_value = b"\xab" * 65
+        service.signer = create_mock_signer(address="0x" + "a" * 40)
 
         # Mock marketplace contract
         mock_contract = MagicMock()
@@ -1507,9 +1509,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = MagicMock()
-        service.signer.address = "0x" + "a" * 40
-        service.signer.sign_message.return_value = b"\xab" * 65
+        service.signer = create_mock_signer(address="0x" + "a" * 40)
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1578,9 +1578,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = MagicMock()
-        service.signer.address = "0x" + "a" * 40
-        service.signer.sign_message.return_value = b"\xab" * 65
+        service.signer = create_mock_signer(address="0x" + "a" * 40)
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1653,9 +1651,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = MagicMock()
-        service.signer.address = "0x" + "a" * 40
-        service.signer.sign_message.return_value = b"\xab" * 65
+        service.signer = create_mock_signer(address="0x" + "a" * 40)
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1908,6 +1904,15 @@ class TestOffchain402Handling:
                 PaymentType.NATIVE,
                 PaymentChallenge(100, 30, "0xbt", "", 100, "ib"),
                 max_delivery_rate=100,
+            )
+            # The child service must inherit the signer (external-signer path
+            # has no crypto to fall back on)
+            mock_ds.assert_called_once_with(
+                chain_config=service.chain_config,
+                agent_mode=service.agent_mode,
+                safe_address=service.safe_address,
+                ethereum_client=service.ethereum_client,
+                signer=service.signer,
             )
             mock_ds.return_value.deposit_native.assert_called_once_with(70)
 

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -24,6 +24,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import requests
+from eth_account import Account
+from eth_account.messages import encode_defunct
 
 from mech_client.domain.signing import LocalSigner
 from mech_client.infrastructure.config import PaymentType
@@ -68,6 +70,24 @@ def create_mock_crypto(private_key: str = "0x" + "1" * 64) -> MagicMock:
     mock_crypto = MagicMock()
     mock_crypto.private_key = private_key
     return mock_crypto
+
+
+# Real key material for the offchain signing path: the request signature is
+# recovered locally against signer.address before the request goes out, so a
+# canned byte string won't do.
+_TEST_ACCOUNT = Account.from_key("0x" + "1" * 64)  # synthetic test key
+
+
+def _real_signing_signer() -> MagicMock:
+    """Create a mock signer that produces real raw-digest signatures.
+
+    :return: Mock signer whose sign_message output recovers to its address
+    """
+    signer = create_mock_signer(address=_TEST_ACCOUNT.address)
+    signer.sign_message.side_effect = lambda digest: bytes(
+        _TEST_ACCOUNT.unsafe_sign_hash(digest).signature
+    )
+    return signer
 
 
 class TestMarketplaceServiceInitialization:
@@ -1432,7 +1452,7 @@ class TestSendOffchainRequest:
         )
 
         # Mock crypto address and signing
-        service.signer = create_mock_signer(address="0x" + "a" * 40)
+        service.signer = _real_signing_signer()
 
         # Mock marketplace contract
         mock_contract = MagicMock()
@@ -1509,7 +1529,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = create_mock_signer(address="0x" + "a" * 40)
+        service.signer = _real_signing_signer()
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1578,7 +1598,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = create_mock_signer(address="0x" + "a" * 40)
+        service.signer = _real_signing_signer()
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1651,7 +1671,7 @@ class TestSendOffchainRequest:
             crypto=create_mock_crypto(),
         )
 
-        service.signer = create_mock_signer(address="0x" + "a" * 40)
+        service.signer = _real_signing_signer()
 
         mock_contract = MagicMock()
         mock_contract.functions.mapNonces.return_value.call.return_value = 0
@@ -1691,6 +1711,71 @@ class TestSendOffchainRequest:
                         extra_attributes=None,
                         timeout=30.0,
                     )
+
+
+class TestSignRequestDigest:
+    """Tests for _sign_request_digest (fire-time ecrecover guard)."""
+
+    @staticmethod
+    def _digest() -> bytes:
+        """Return a fixed 32-byte request-id digest.
+
+        :return: 32-byte digest
+        """
+        return b"\x11" * 32
+
+    def test_valid_signature_passes_and_is_hex_encoded(self) -> None:
+        """A raw-digest signature recovers to the signer and is returned."""
+        service = _build_offchain_service()
+        service.signer = _real_signing_signer()
+
+        signature = service._sign_request_digest(self._digest())
+
+        expected = bytes(_TEST_ACCOUNT.unsafe_sign_hash(self._digest()).signature)
+        assert signature == "0x" + expected.hex()
+
+    def test_low_v_signature_is_normalized_for_recovery_only(self) -> None:
+        """A signer using v in {0, 1} passes; original bytes are sent."""
+        service = _build_offchain_service()
+        real = bytes(_TEST_ACCOUNT.unsafe_sign_hash(self._digest()).signature)
+        low_v = real[:64] + bytes([real[64] - 27])
+        service.signer = create_mock_signer(
+            address=_TEST_ACCOUNT.address, signature=low_v
+        )
+
+        signature = service._sign_request_digest(self._digest())
+
+        # The low-v original goes out; normalization is check-only
+        assert signature == "0x" + low_v.hex()
+
+    def test_eip191_signature_is_rejected_with_diagnostic(self) -> None:
+        """An EIP-191 personal-message signature recovers to the wrong address."""
+        service = _build_offchain_service()
+        eip191 = bytes(
+            _TEST_ACCOUNT.sign_message(encode_defunct(self._digest())).signature
+        )
+        service.signer = create_mock_signer(
+            address=_TEST_ACCOUNT.address, signature=eip191
+        )
+
+        with pytest.raises(ValueError, match="EIP-191"):
+            service._sign_request_digest(self._digest())
+
+    def test_wrong_length_signature_is_rejected(self) -> None:
+        """A non-65-byte signature fails fast with a clear message."""
+        service = _build_offchain_service()
+        service.signer = create_mock_signer(signature=b"\xab" * 64)
+
+        with pytest.raises(ValueError, match="expected\\s+65 bytes"):
+            service._sign_request_digest(self._digest())
+
+    def test_unrecoverable_signature_is_rejected(self) -> None:
+        """A malformed signature (r = s = 0) surfaces a diagnostic error."""
+        service = _build_offchain_service()
+        service.signer = create_mock_signer(signature=b"\x00" * 64 + b"\x1b")
+
+        with pytest.raises(ValueError, match="cannot be recovered"):
+            service._sign_request_digest(self._digest())
 
 
 class TestSendRequestOffchainBranch:


### PR DESCRIPTION
## Summary

Closes #244.

Some mech-client consumers cannot hold a raw private key in-process (e.g. Pearl BYOA-style agents, where key custody lives in a separate local signer service). This PR introduces a `Signer` abstraction and routes **all** signing through it, with the existing behavior preserved as the default.

```python
@runtime_checkable
class Signer(Protocol):
    @property
    def address(self) -> str: ...
    def send_transaction(self, unsigned_tx: dict) -> str: ...
    def sign_message(self, message: bytes) -> bytes: ...
```

- `MarketplaceService` / `DepositService` (and the shared `BaseTransactionService`) accept `signer=` as an alternative to `crypto=`.
- `LocalSigner` (wrapping `EthereumCrypto` + ledger API) is the default and preserves historic signing behavior byte-for-byte.

## Call sites routed through the signer

1. **Agent-mode SafeTx execution** — `SafeTx.sign(private_key)` / `SafeTx.execute(private_key)` are replaced by the Safe **pre-validated signature** encoding (`r` = owner address left-padded to 32 bytes, `s = 0`, `v = 1`), valid because the outer `execTransaction` sender is that owner. The outer tx is built via `SafeTx.w3_tx` and submitted through `signer.send_transaction(...)`. Outer gas sizing follows #243 (merged separately on `main`): `safe_tx_gas=0` forwards all gas to the inner call, and an explicit `tx_gas = int(estimate * 1.1) + max(250k, 5% of estimate)` skips the outer `eth_estimateGas` that the EIP-150 63/64 rule would otherwise revert — this PR only changes *who signs and broadcasts* that outer tx, not how its gas is sized. No ECDSA over the SafeTx hash is needed, so no raw-hash signing capability is required from the signer service.
2. **Deposits** — native and token deposits build unsigned EOA transactions and submit via `signer.send_transaction(...)` (client mode) or the Safe path above (agent mode).
3. **Off-chain requests** — the request-id signature comes from `signer.sign_message(...)`. Note: the on-chain verifier (`MechMarketplace.sol`) recovers with plain `ecrecover(requestHash, v, r, s)` on the **raw 32-byte digest** — no EIP-191 prefix (the issue text says "EIP-191", but the contract and the historic `unsafe_sign_hash` behavior both use direct digest signing; the `Signer.sign_message` docstring documents this precisely so external implementers get it right).

## Backwards compatibility

- `crypto=` keeps working unchanged everywhere (wrapped in `LocalSigner` internally); `SubscriptionService` and the CLI are untouched.
- Offchain signature bytes and payload format are byte-for-byte identical to before.
- `SafeClient.send_transaction` returns `HexBytes` and propagates failures as exceptions (matching post-#243 `main`); malformed signer addresses fail with a diagnostic `ValueError`.
- Per review feedback, services no longer store `crypto` / `private_key` attributes (they were dead state — all signing goes through `service.signer`); the `crypto=` constructor argument itself is unchanged.

## Acceptance criteria (from #244)

- [x] Agent-mode marketplace request paid by a Safe, executed via pre-validated signature + externally signed outer tx
- [x] `deposit_native()` and token deposits through the signer
- [x] Off-chain prepaid request signing through the signer
- [x] Existing `crypto=`/private-key usage unchanged (`LocalSigner` default)

## Docs

- `docs/ARCHITECTURE.md`: new `domain/signing/` section
- `README.md`: "Using an external signer (no private key in-process)" guide
- `mech_client/__init__.py`: exports `Signer` / `LocalSigner` with a usage example

## Testing

- 747 unit tests pass, coverage stays at 100% (2867/2867 statements)
- New `tests/unit/domain/test_signing.py` (protocol conformance, `LocalSigner` nonce/gas fill, EIP-1559 non-override, input immutability, digest signing)
- Safe client tests rewritten for the pre-validated flow (encoding layout, gas floor, owner-address validation, failure paths); executor and service tests updated; signer-only service construction covered
- All linters green: black, isort, flake8, mypy, pylint (10.00/10), darglint, bandit, copyright check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
