### PR TITLE
feat(marketplace): bind offchain requester to the Safe in agent mode

### DIFF
--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -35,7 +35,7 @@ instead of ``crypto``:
     ... )
 """
 
-__version__ = "0.21.2"
+__version__ = "0.21.3"
 
 # Signing
 from mech_client.domain.signing import LocalSigner, Signer

--- a/mech_client/domain/signing/base.py
+++ b/mech_client/domain/signing/base.py
@@ -75,7 +75,7 @@ class Signer(Protocol):
         Used by the agent-mode offchain marketplace flow, where the requester
         of record is a Safe multisig (not the signing EOA). The marketplace
         verifies via ``Safe.isValidSignature(digest, sig)``, which on Safe
-        v1.4.1 with the standard ``CompatibilityFallbackHandler`` rehashes
+        v1.3.0+ with the standard ``CompatibilityFallbackHandler`` rehashes
         the raw ``digest`` into an EIP-712 ``SafeMessage`` and checks that
         the sig recovers to an owner over the wrapped hash. A raw
         ``ecrecover`` signature over ``digest`` fails on-chain with
@@ -91,17 +91,32 @@ class Signer(Protocol):
         to ``Safe.getMessageHash``) and sign it raw (``v`` in ``{27, 28}``).
         The signer must be an owner of ``safe_address``.
 
+        ``message`` MUST be exactly 32 bytes. Callers pass the request-id
+        digest; the wrapping formula's shortcut ``keccak256(message)`` only
+        equals ``keccak256(abi.encode(bytes32, message))`` at 32 bytes, so
+        any other length silently signs a hash the fallback handler will
+        not accept. Implementations MUST reject non-32-byte inputs.
+
         This is a required protocol member. Downstream implementers of
         :class:`Signer` (e.g. Pearl BYOA agents) must add this method to
         remain compatible with agent-mode offchain requests. Existing
         :meth:`sign_message` is unchanged and continues to serve client mode.
 
-        Domain assumption: Safe v1.4.1. Older Safes (v1.3.0) use a domain
-        typehash without ``chainId`` and are not supported by this method.
+        Domain assumption: Safe v1.3.0+ (v1.3.0 and v1.4.1 share the
+        ``EIP712Domain(uint256 chainId,address verifyingContract)``
+        typehash and the same ``SafeMessage`` wrapping). ``mechx setup``
+        deploys the canonical Safe v1.3.0 singleton, so this method
+        targets that domain. Pre-v1.3.0 Safes (v1.2.0 and earlier) use a
+        domain typehash without ``chainId`` and are not supported.
+
+        The Safe's signature threshold must be 1 for this single-owner
+        signature to validate. Safes with threshold > 1 will reject the
+        signature via ``checkNSignatures`` (a distinct failure mode from
+        ``GS026``).
 
         :param safe_address: Checksummed Safe address (verifyingContract in
             the EIP-712 domain)
         :param chain_id: Chain ID of the network the Safe is deployed on
-        :param message: Message bytes to wrap and sign (32-byte digest for
-            mech requests)
+        :param message: 32-byte digest to wrap and sign (the mech
+            request-id digest)
         """

--- a/mech_client/domain/signing/base.py
+++ b/mech_client/domain/signing/base.py
@@ -57,12 +57,51 @@ class Signer(Protocol):
     def sign_message(self, message: bytes) -> bytes:
         """Return a 65-byte ECDSA signature (r ‖ s ‖ v) over ``message``.
 
-        The mech marketplace flow passes the raw 32-byte request-id digest
-        here, and the on-chain verifier recovers it with plain
-        ``ecrecover(digest, v, r, s)`` — i.e. the digest must be signed
-        directly (``eth_account``'s ``unsafe_sign_hash`` semantics), NOT
-        wrapped in an EIP-191 personal-message prefix. ``v`` may be
+        Used by the client-mode offchain marketplace flow: the EOA is the
+        requester of record, and the marketplace verifier recovers with
+        plain ``ecrecover(digest, v, r, s)`` — i.e. the digest must be
+        signed directly (``eth_account``'s ``unsafe_sign_hash`` semantics),
+        NOT wrapped in an EIP-191 personal-message prefix. ``v`` may be
         ``{0, 1}`` or ``{27, 28}``; the contract normalizes both.
 
         :param message: Message bytes to sign (32-byte digest for mech requests)
+        """
+
+    def sign_safe_message(
+        self, safe_address: str, chain_id: int, message: bytes
+    ) -> bytes:
+        """Return a 65-byte ECDSA signature over the Safe-wrapped ``message``.
+
+        Used by the agent-mode offchain marketplace flow, where the requester
+        of record is a Safe multisig (not the signing EOA). The marketplace
+        verifies via ``Safe.isValidSignature(digest, sig)``, which on Safe
+        v1.4.1 with the standard ``CompatibilityFallbackHandler`` rehashes
+        the raw ``digest`` into an EIP-712 ``SafeMessage`` and checks that
+        the sig recovers to an owner over the wrapped hash. A raw
+        ``ecrecover`` signature over ``digest`` fails on-chain with
+        ``GS026``; the signature MUST be produced over::
+
+            wrappedHash = keccak256(
+                0x1901
+                || keccak256(abi.encode(DOMAIN_TYPEHASH, chainId, safe))
+                || keccak256(abi.encode(SAFE_MSG_TYPEHASH, keccak256(abi.encode(message))))
+            )
+
+        Implementations MUST compute ``wrappedHash`` locally (no RPC call
+        to ``Safe.getMessageHash``) and sign it raw (``v`` in ``{27, 28}``).
+        The signer must be an owner of ``safe_address``.
+
+        This is a required protocol member. Downstream implementers of
+        :class:`Signer` (e.g. Pearl BYOA agents) must add this method to
+        remain compatible with agent-mode offchain requests. Existing
+        :meth:`sign_message` is unchanged and continues to serve client mode.
+
+        Domain assumption: Safe v1.4.1. Older Safes (v1.3.0) use a domain
+        typehash without ``chainId`` and are not supported by this method.
+
+        :param safe_address: Checksummed Safe address (verifyingContract in
+            the EIP-712 domain)
+        :param chain_id: Chain ID of the network the Safe is deployed on
+        :param message: Message bytes to wrap and sign (32-byte digest for
+            mech requests)
         """

--- a/mech_client/domain/signing/local.py
+++ b/mech_client/domain/signing/local.py
@@ -22,6 +22,18 @@
 from typing import Any, Dict
 
 from aea_ledger_ethereum import EthereumApi, EthereumCrypto
+from eth_abi import encode as abi_encode
+from eth_account import Account
+from eth_utils import keccak
+from mech_client.utils.validators import ensure_checksummed_address
+
+# EIP-712 typehash constants for Safe v1.4.1 SafeMessage wrapping.
+# Recomputed as keccak of the type string below so a reader can diff them
+# against the on-chain constants without decoding hex.
+_EIP712_DOMAIN_TYPEHASH = keccak(
+    text="EIP712Domain(uint256 chainId,address verifyingContract)"
+)
+_SAFE_MESSAGE_TYPEHASH = keccak(text="SafeMessage(bytes message)")
 
 
 class LocalSigner:
@@ -87,3 +99,45 @@ class LocalSigner:
         """
         signature = self.crypto.sign_message(message, is_deprecated_mode=True)
         return bytes.fromhex(signature.removeprefix("0x"))
+
+    def sign_safe_message(
+        self, safe_address: str, chain_id: int, message: bytes
+    ) -> bytes:
+        """Sign the Safe-wrapped EIP-712 hash of ``message`` with the local key.
+
+        Computes the SafeMessage wrapped hash locally (no RPC) and signs it
+        raw so ``Safe.isValidSignature(message, sig)`` returns the ERC-1271
+        magic value on-chain — see :meth:`Signer.sign_safe_message` for the
+        formula and domain assumptions.
+
+        :param safe_address: Safe (verifyingContract) address
+        :param chain_id: Chain ID for the EIP-712 domain
+        :param message: Message bytes to wrap and sign
+        :return: 65-byte signature (r ‖ s ‖ v) over the wrapped hash
+        """
+        checksummed_safe = ensure_checksummed_address(safe_address)
+        domain_separator = keccak(
+            abi_encode(
+                ["bytes32", "uint256", "address"],
+                [_EIP712_DOMAIN_TYPEHASH, chain_id, checksummed_safe],
+            )
+        )
+        # ``Safe.isValidSignature(bytes32 hash, bytes sig)`` on the
+        # v1.4.1 CompatibilityFallbackHandler wraps ``hash`` as
+        # ``keccak256(abi.encode(hash))`` before hashing into
+        # ``SafeMessage``. For a 32-byte input, ``abi.encode(bytes32)``
+        # yields the same 32 bytes, so ``keccak256(message)`` here is
+        # exactly ``keccak256(<32 raw bytes>)`` — the same value the
+        # handler computes on-chain.
+        struct_hash = keccak(
+            abi_encode(
+                ["bytes32", "bytes32"],
+                [_SAFE_MESSAGE_TYPEHASH, keccak(message)],
+            )
+        )
+        wrapped_hash = keccak(b"\x19\x01" + domain_separator + struct_hash)
+        # pylint: disable-next=no-value-for-parameter
+        signed = Account.unsafe_sign_hash(
+            wrapped_hash, private_key=self.crypto.private_key
+        )
+        return bytes(signed.signature)

--- a/mech_client/domain/signing/local.py
+++ b/mech_client/domain/signing/local.py
@@ -27,13 +27,20 @@ from eth_account import Account
 from eth_utils import keccak
 from mech_client.utils.validators import ensure_checksummed_address
 
-# EIP-712 typehash constants for Safe v1.4.1 SafeMessage wrapping.
-# Recomputed as keccak of the type string below so a reader can diff them
-# against the on-chain constants without decoding hex.
+# EIP-712 typehash constants for Safe v1.3.0+ SafeMessage wrapping (the
+# chainId-in-domain typehash was introduced in v1.3.0 and unchanged in
+# v1.4.1). Recomputed as keccak of the type string below so a reader can
+# diff them against the on-chain constants without decoding hex.
 _EIP712_DOMAIN_TYPEHASH = keccak(
     text="EIP712Domain(uint256 chainId,address verifyingContract)"
 )
 _SAFE_MESSAGE_TYPEHASH = keccak(text="SafeMessage(bytes message)")
+
+# ``sign_safe_message`` shortcut ``keccak256(message)`` for the inner
+# ``keccak256(abi.encode(bytes32, message))`` only holds at exactly 32
+# bytes. Any other length silently signs a hash Safe.isValidSignature
+# will reject.
+_SAFE_MESSAGE_REQUIRED_LEN = 32
 
 
 class LocalSigner:
@@ -107,14 +114,21 @@ class LocalSigner:
 
         Computes the SafeMessage wrapped hash locally (no RPC) and signs it
         raw so ``Safe.isValidSignature(message, sig)`` returns the ERC-1271
-        magic value on-chain — see :meth:`Signer.sign_safe_message` for the
+        magic value on-chain, see :meth:`Signer.sign_safe_message` for the
         formula and domain assumptions.
 
         :param safe_address: Safe (verifyingContract) address
         :param chain_id: Chain ID for the EIP-712 domain
-        :param message: Message bytes to wrap and sign
+        :param message: 32-byte digest to wrap and sign
         :return: 65-byte signature (r ‖ s ‖ v) over the wrapped hash
+        :raises ValueError: if ``message`` is not exactly 32 bytes
         """
+        if len(message) != _SAFE_MESSAGE_REQUIRED_LEN:
+            raise ValueError(
+                f"sign_safe_message requires a "
+                f"{_SAFE_MESSAGE_REQUIRED_LEN}-byte digest, got "
+                f"{len(message)} bytes. See Signer.sign_safe_message."
+            )
         checksummed_safe = ensure_checksummed_address(safe_address)
         domain_separator = keccak(
             abi_encode(
@@ -123,11 +137,11 @@ class LocalSigner:
             )
         )
         # ``Safe.isValidSignature(bytes32 hash, bytes sig)`` on the
-        # v1.4.1 CompatibilityFallbackHandler wraps ``hash`` as
+        # v1.3.0+ CompatibilityFallbackHandler wraps ``hash`` as
         # ``keccak256(abi.encode(hash))`` before hashing into
         # ``SafeMessage``. For a 32-byte input, ``abi.encode(bytes32)``
         # yields the same 32 bytes, so ``keccak256(message)`` here is
-        # exactly ``keccak256(<32 raw bytes>)`` — the same value the
+        # exactly ``keccak256(<32 raw bytes>)``, the same value the
         # handler computes on-chain.
         struct_hash = keccak(
             abi_encode(

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -376,8 +376,12 @@ class MarketplaceService(
         """
         logger.info("Sending offchain mech marketplace request...")
 
-        # Get current nonce from contract
-        sender = self.signer.address
+        # In agent mode the requester of record is the Safe (msg.sender on
+        # the on-chain path, ``mapNonces`` key, and requester bound into
+        # ``getRequestId``); in client mode it is the EOA. The signature is
+        # verified against this address downstream (Safe.isValidSignature
+        # for the Safe branch, plain ecrecover for the EOA branch).
+        sender = self._resolve_offchain_sender()
         current_nonce = marketplace_contract.functions.mapNonces(sender).call()
 
         # Prepare and send each request
@@ -414,8 +418,10 @@ class MarketplaceService(
             request_id_int = int.from_bytes(request_id_bytes, byteorder="big")
             request_id_hex = request_id_bytes.hex()
 
-            # Sign the request ID digest (raw ecrecover on-chain, no EIP-191
-            # prefix — see Signer.sign_message)
+            # Signature encoding depends on how the marketplace verifies the
+            # requester: Safe.isValidSignature (agent mode) requires the
+            # SafeMessage-wrapped hash to be signed; plain ecrecover
+            # (client mode) requires the raw digest.
             signature = self._sign_request_digest(request_id_bytes)
 
             # Prepare payload
@@ -466,24 +472,65 @@ class MarketplaceService(
             "receipt": None,  # No receipt for offchain requests
         }
 
-    def _sign_request_digest(self, request_id_bytes: bytes) -> str:
-        """Sign the request-id digest via the signer and verify recoverability.
+    def _resolve_offchain_sender(self) -> str:
+        """Return the requester address bound into the offchain request.
 
-        The marketplace contract validates offchain requests with plain
-        ``ecrecover(digest, v, r, s)``, so the signature must be over the raw
-        32-byte digest — NOT wrapped in an EIP-191 personal-message prefix.
-        External signer services commonly default to EIP-191
+        In agent mode this is the Safe (matching the onchain flow where the
+        Safe is ``msg.sender`` on the marketplace call); in client mode it
+        is the EOA. Callers use this for ``mapNonces``, ``getRequestId``,
+        and the payload ``sender`` field so the mech, subgraph, and
+        settlement path all agree on who owns the request.
+
+        :return: Checksummed requester address
+        :raises ValueError: if agent mode is set but no Safe address was
+            passed to the service constructor
+        """
+        if self.agent_mode:
+            if not self.safe_address:
+                raise ValueError(
+                    "Agent-mode offchain requests require a Safe address; "
+                    "pass safe_address=... to MarketplaceService."
+                )
+            return ensure_checksummed_address(self.safe_address)
+        return ensure_checksummed_address(self.signer.address)
+
+    def _sign_request_digest(self, request_id_bytes: bytes) -> str:
+        """Sign the request-id digest and return the 0x-prefixed hex signature.
+
+        Client mode: sign the raw 32-byte digest so the marketplace's
+        ``ecrecover(digest, v, r, s)`` recovers to the EOA. External signer
+        services commonly default to EIP-191
         (``eth_account.Account.sign_message``), which produces a signature
         that recovers to a *different* address; on-chain that fails silently
         (the request is treated as coming from an unpaid sender). Recovering
         locally and comparing against ``signer.address`` turns that
         misconfiguration into an immediate, actionable error at fire time.
 
+        Agent mode: sign the SafeMessage-wrapped hash so
+        ``Safe.isValidSignature(digest, sig)`` returns the ERC-1271 magic
+        value on-chain. Raw-digest signing fails with ``GS026`` on Safe
+        v1.4.1 with the standard fallback handler. The wrapped hash is
+        computed locally by the signer (no RPC round-trip).
+
         :param request_id_bytes: the 32-byte request-id digest to sign.
         :return: 0x-prefixed hex signature, as sent to the mech.
-        :raises ValueError: if the signature has the wrong length or does not
-            recover to the signer's address (e.g. the signer applied EIP-191).
+        :raises ValueError: if the signature has the wrong length or
+            (client mode) does not recover to the signer's address.
         """
+        if self.agent_mode:
+            signature = self.signer.sign_safe_message(
+                self._resolve_offchain_sender(),
+                self.mech_config.ledger_config.chain_id,
+                request_id_bytes,
+            )
+            if len(signature) != 65:
+                raise ValueError(
+                    f"Signer returned a {len(signature)}-byte signature; "
+                    f"expected 65 bytes (r ‖ s ‖ v). See "
+                    f"Signer.sign_safe_message."
+                )
+            return "0x" + signature.hex()
+
         signature = self.signer.sign_message(request_id_bytes)
         if len(signature) != 65:
             raise ValueError(

--- a/mech_client/services/marketplace_service.py
+++ b/mech_client/services/marketplace_service.py
@@ -422,7 +422,7 @@ class MarketplaceService(
             # requester: Safe.isValidSignature (agent mode) requires the
             # SafeMessage-wrapped hash to be signed; plain ecrecover
             # (client mode) requires the raw digest.
-            signature = self._sign_request_digest(request_id_bytes)
+            signature = self._sign_request_digest(sender, request_id_bytes)
 
             # Prepare payload
             payload = {
@@ -494,7 +494,7 @@ class MarketplaceService(
             return ensure_checksummed_address(self.safe_address)
         return ensure_checksummed_address(self.signer.address)
 
-    def _sign_request_digest(self, request_id_bytes: bytes) -> str:
+    def _sign_request_digest(self, sender: str, request_id_bytes: bytes) -> str:
         """Sign the request-id digest and return the 0x-prefixed hex signature.
 
         Client mode: sign the raw 32-byte digest so the marketplace's
@@ -509,17 +509,34 @@ class MarketplaceService(
         Agent mode: sign the SafeMessage-wrapped hash so
         ``Safe.isValidSignature(digest, sig)`` returns the ERC-1271 magic
         value on-chain. Raw-digest signing fails with ``GS026`` on Safe
-        v1.4.1 with the standard fallback handler. The wrapped hash is
+        v1.3.0+ with the standard fallback handler. The wrapped hash is
         computed locally by the signer (no RPC round-trip).
 
+        ``sender`` is the requester of record already resolved by the
+        caller (Safe in agent mode, EOA in client mode). Threading it in
+        rather than re-resolving keeps the address the signature is bound
+        to identical to the address the caller wrote into the payload and
+        ``getRequestId``.
+
+        :param sender: Checksummed requester address (agent mode: Safe;
+            client mode: EOA). Must equal the ``sender`` field of the
+            outbound payload and the requester argument to
+            ``getRequestId``.
         :param request_id_bytes: the 32-byte request-id digest to sign.
         :return: 0x-prefixed hex signature, as sent to the mech.
-        :raises ValueError: if the signature has the wrong length or
-            (client mode) does not recover to the signer's address.
+        :raises ValueError: if the signature has the wrong length, uses an
+            unsupported ``v`` byte, or (client mode) does not recover to
+            the signer's address.
         """
         if self.agent_mode:
+            if not hasattr(self.signer, "sign_safe_message"):
+                raise ValueError(
+                    "The provided Signer implementation must define "
+                    "sign_safe_message for agent-mode offchain requests. "
+                    "See mech_client.domain.signing.Signer."
+                )
             signature = self.signer.sign_safe_message(
-                self._resolve_offchain_sender(),
+                sender,
                 self.mech_config.ledger_config.chain_id,
                 request_id_bytes,
             )
@@ -528,6 +545,14 @@ class MarketplaceService(
                     f"Signer returned a {len(signature)}-byte signature; "
                     f"expected 65 bytes (r ‖ s ‖ v). See "
                     f"Signer.sign_safe_message."
+                )
+            if signature[64] not in (27, 28):
+                raise ValueError(
+                    f"Signer returned v={signature[64]}; "
+                    f"sign_safe_message requires raw-hash signing with v "
+                    f"in {{27, 28}} (v=0 is read as a contract signature "
+                    f"and v=1 as an approved hash by Safe, both fail as "
+                    f"GS026). See Signer.sign_safe_message."
                 )
             return "0x" + signature.hex()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "mech-client"
-version = "0.21.2"
+version = "0.21.3"
 description = "Basic client to interact with a mech"
 requires-python = ">=3.10,<3.15"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "open-aea-helpers==0.21.25",
+    "open-aea-helpers==0.21.26",
     "gql>=3.4.1",
     "tabulate>=0.9.0,<0.10",
     "setuptools>=78.1.1,<82",
@@ -44,7 +44,7 @@ service_specific_packages = ["mech_client", "scripts"]
 pytest_targets = ["tests/unit"]
 # Library, not a runtime open-autonomy app — set explicitly so tomte's
 # liccheck / check-third-party-hashes envs render valid upstream pins.
-open_autonomy_version = "0.21.25"
+open_autonomy_version = "0.21.26"
 open_aea_version = "2.2.9"
 # 32-byte keccak hashes (public protocol identifiers, not credentials)
 # trip gitleaks' generic-secret rule. `marketplace_interact.py` was

--- a/tests/unit/domain/test_signing.py
+++ b/tests/unit/domain/test_signing.py
@@ -54,6 +54,12 @@ class TestSignerProtocol:
                 """Pretend to sign a digest."""
                 return b"\x00" * 65
 
+            def sign_safe_message(
+                self, safe_address: str, chain_id: int, message: bytes
+            ) -> bytes:
+                """Pretend to sign a Safe-wrapped digest."""
+                return b"\x00" * 65
+
         assert isinstance(RemoteSigner(), Signer)
 
 
@@ -231,3 +237,163 @@ class TestLocalSignerSignMessage:
             digest, signature=signature
         )
         assert recovered == crypto.address
+
+
+# Reference vector produced against a Gnosis-fork anvil instance with a
+# fresh Safe v1.4.1 deployed via SafeProxyFactory 0x4e1D...c67 + singleton
+# 0x4167...61a + CompatibilityFallbackHandler 0xfd07...c99. The signature
+# below was verified on-fork: ``Safe.isValidSignature(REQUEST_ID, SIG)``
+# returned the ERC-1271 magic value ``0x1626ba7e``. Encoding this as
+# module-level constants keeps the round-trip auditable: a reader can
+# reproduce the vector by re-running the fork commands in the PR body.
+_SAFE_FORK_SAFE_ADDRESS = "0x56f3a6943924e88e6aeb4278b88dcafbb9c2d7ae"
+_SAFE_FORK_CHAIN_ID = 100
+# Anvil account 0 default key — a public test constant, not a credential.
+_SAFE_FORK_OWNER_KEY = (
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+)
+_SAFE_FORK_REQUEST_ID = bytes.fromhex(
+    "1111111111111111111111111111111111111111111111111111111111111111"
+)
+_SAFE_FORK_EXPECTED_SIGNATURE = bytes.fromhex(
+    "df56c320b8a9fd9d7ca5a9393d59d47e1f973c4fa473f6a119949effe580a6c3"
+    "7dcc822b76790bf0c713dd19932e3016366edd71cefbe59386ae7f65819443581c"
+)
+
+
+class TestLocalSignerSignSafeMessage:
+    """Tests for LocalSigner.sign_safe_message (Safe v1.4.1 wrapping)."""
+
+    @staticmethod
+    def _signer_for_key(private_key: str, tmp_path: Path) -> LocalSigner:
+        """Build a LocalSigner wrapping ``private_key``.
+
+        :param private_key: 0x-prefixed hex private key
+        :param tmp_path: pytest tmp_path fixture
+        :return: LocalSigner backed by an EthereumCrypto over the key
+        """
+        key_file = tmp_path / "key.txt"
+        key_file.write_text(private_key)
+        crypto = EthereumCrypto(private_key_path=str(key_file))
+        return LocalSigner(crypto, MagicMock())
+
+    def test_signature_matches_fork_verified_reference(
+        self, tmp_path: Path
+    ) -> None:
+        """The locally computed wrapped-hash signature matches the fork vector.
+
+        This is the invariant that makes Safe.isValidSignature accept the
+        signature on-chain: the wrapping formula (domain separator + struct
+        hash + \\x19\\x01 prefix) must byte-for-byte match Safe v1.4.1's
+        CompatibilityFallbackHandler. A drift in either constant, in the
+        abi.encode layout, or in the raw-hash signing convention would flip
+        this byte string and be caught here before it reaches the mech.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        signature = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert signature == _SAFE_FORK_EXPECTED_SIGNATURE
+        assert len(signature) == 65
+        # Raw ECDSA, so v is in {27, 28}
+        assert signature[64] in (27, 28)
+
+    def test_returns_bytes_type(self, tmp_path: Path) -> None:
+        """The return value is ``bytes``, not a hex string or SignedMessage."""
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        signature = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert isinstance(signature, bytes)
+
+    def test_different_safe_address_yields_different_signature(
+        self, tmp_path: Path
+    ) -> None:
+        """The Safe address enters the domain separator.
+
+        Two different Safe addresses (same owner key, same chain, same
+        request id) must produce different signatures, otherwise the
+        verifyingContract is not being bound into the wrapped hash and the
+        signature could be replayed against a different Safe controlled by
+        the same owner.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+        other_safe = "0x" + "a" * 40
+
+        sig_a = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+        sig_b = signer.sign_safe_message(
+            other_safe,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert sig_a != sig_b
+
+    def test_different_chain_id_yields_different_signature(
+        self, tmp_path: Path
+    ) -> None:
+        """The chain id enters the domain separator.
+
+        Two different chain ids (same Safe address, same owner, same
+        request id) must produce different signatures — otherwise the
+        signature could be replayed across chains where the same Safe
+        address exists.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        sig_gnosis = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS, 100, _SAFE_FORK_REQUEST_ID
+        )
+        sig_base = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS, 8453, _SAFE_FORK_REQUEST_ID
+        )
+
+        assert sig_gnosis != sig_base
+
+    def test_different_message_yields_different_signature(
+        self, tmp_path: Path
+    ) -> None:
+        """The message enters the struct hash — same domain, different digest."""
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+        other_digest = b"\x22" * 32
+
+        sig_a = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+        sig_b = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            other_digest,
+        )
+
+        assert sig_a != sig_b
+
+    def test_lowercase_safe_address_accepted(self, tmp_path: Path) -> None:
+        """Callers may pass an unchecksummed address; result is unchanged.
+
+        The wrapper normalizes to a checksummed address internally so the
+        domain separator is invariant to the caller's casing.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        sig_lower = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS.lower(),
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert sig_lower == _SAFE_FORK_EXPECTED_SIGNATURE

--- a/tests/unit/domain/test_signing.py
+++ b/tests/unit/domain/test_signing.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock
 
+import pytest
 from aea_ledger_ethereum import EthereumCrypto
 from eth_account import Account
 
@@ -241,14 +242,12 @@ class TestLocalSignerSignMessage:
 
 # Reference vector produced against a Gnosis-fork anvil instance with a
 # fresh Safe v1.4.1 deployed via SafeProxyFactory 0x4e1D...c67 + singleton
-# 0x4167...61a + CompatibilityFallbackHandler 0xfd07...c99. The signature
-# below was verified on-fork: ``Safe.isValidSignature(REQUEST_ID, SIG)``
-# returned the ERC-1271 magic value ``0x1626ba7e``. Encoding this as
-# module-level constants keeps the round-trip auditable: a reader can
-# reproduce the vector by re-running the fork commands in the PR body.
+# 0x4167...61a + CompatibilityFallbackHandler 0xfd07...c99. Verified
+# on-fork: ``Safe.isValidSignature(REQUEST_ID, SIG)`` returned the
+# ERC-1271 magic value ``0x1626ba7e``.
 _SAFE_FORK_SAFE_ADDRESS = "0x56f3a6943924e88e6aeb4278b88dcafbb9c2d7ae"
 _SAFE_FORK_CHAIN_ID = 100
-# Anvil account 0 default key — a public test constant, not a credential.
+# Anvil account 0 default key, a public test constant, not a credential.
 _SAFE_FORK_OWNER_KEY = (
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 )
@@ -260,9 +259,26 @@ _SAFE_FORK_EXPECTED_SIGNATURE = bytes.fromhex(
     "7dcc822b76790bf0c713dd19932e3016366edd71cefbe59386ae7f65819443581c"
 )
 
+# Second reference vector produced against a Gnosis-fork anvil instance
+# with a fresh Safe v1.3.0 deployed via SafeProxyFactory
+# ``0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2`` + singleton
+# ``0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552`` + fallback handler
+# ``0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4``. This is the version
+# ``mechx setup`` (via olas-operate-middleware) deploys on every
+# supported chain, so it's the deployment every real agent-mode user
+# will have. Verified on-fork: ``Safe.isValidSignature(REQUEST_ID, SIG)``
+# returned the ERC-1271 magic value ``0x1626ba7e``. Same owner key,
+# same chain_id, same request-id digest as the v1.4.1 vector; the two
+# signatures differ only because each Safe has a different deployment
+# address (which enters the domain separator).
+_SAFE_V130_FORK_ADDRESS = "0x8bcb8c0321efeae6b1daeb02273b28e71aeea0ed"
+_SAFE_V130_FORK_EXPECTED_SIGNATURE = bytes.fromhex(
+    "604f709329907e68906860f747b45e236add71ca044a01b718e72328c6a9e767"
+    "2b3c04a6e3eecd5562ecd0103646df7c3e5c700b13c2cf8ab098822c58d0225e1c"
+)
 
 class TestLocalSignerSignSafeMessage:
-    """Tests for LocalSigner.sign_safe_message (Safe v1.4.1 wrapping)."""
+    """Tests for LocalSigner.sign_safe_message (Safe v1.3.0+ wrapping)."""
 
     @staticmethod
     def _signer_for_key(private_key: str, tmp_path: Path) -> LocalSigner:
@@ -284,7 +300,7 @@ class TestLocalSignerSignSafeMessage:
 
         This is the invariant that makes Safe.isValidSignature accept the
         signature on-chain: the wrapping formula (domain separator + struct
-        hash + \\x19\\x01 prefix) must byte-for-byte match Safe v1.4.1's
+        hash + \\x19\\x01 prefix) must byte-for-byte match Safe v1.3.0+'s
         CompatibilityFallbackHandler. A drift in either constant, in the
         abi.encode layout, or in the raw-hash signing convention would flip
         this byte string and be caught here before it reaches the mech.
@@ -300,6 +316,30 @@ class TestLocalSignerSignSafeMessage:
         assert signature == _SAFE_FORK_EXPECTED_SIGNATURE
         assert len(signature) == 65
         # Raw ECDSA, so v is in {27, 28}
+        assert signature[64] in (27, 28)
+
+    def test_signature_matches_v130_fork_verified_reference(
+        self, tmp_path: Path
+    ) -> None:
+        """The wrapped-hash signature matches the Safe v1.3.0 fork vector.
+
+        ``mechx setup`` deploys the canonical Safe v1.3.0 singleton on
+        every supported chain, so v1.3.0 is the actual deployment every
+        agent-mode user has. Pinning this second vector alongside the
+        v1.4.1 vector ensures a future regression that broke either
+        version's wrapping fails the suite, rather than only surfacing
+        against whichever version the fork happened to run against.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        signature = signer.sign_safe_message(
+            _SAFE_V130_FORK_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert signature == _SAFE_V130_FORK_EXPECTED_SIGNATURE
+        assert len(signature) == 65
         assert signature[64] in (27, 28)
 
     def test_returns_bytes_type(self, tmp_path: Path) -> None:
@@ -397,3 +437,51 @@ class TestLocalSignerSignSafeMessage:
         )
 
         assert sig_lower == _SAFE_FORK_EXPECTED_SIGNATURE
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            b"",
+            b"\x11" * 31,
+            b"\x11" * 33,
+            b"\x11" * 64,
+        ],
+    )
+    def test_sign_safe_message_rejects_non_32_byte_message(
+        self, tmp_path: Path, message: bytes
+    ) -> None:
+        """The signer requires a 32-byte digest.
+
+        The wrapping shortcut ``keccak256(message)`` only equals
+        ``keccak256(abi.encode(bytes32, message))`` at exactly 32 bytes.
+        Any other length would silently sign a hash that
+        ``Safe.isValidSignature`` will not accept; rejecting the input
+        surfaces the misuse before the request leaves the client.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        with pytest.raises(ValueError, match="32-byte digest"):
+            signer.sign_safe_message(
+                _SAFE_FORK_SAFE_ADDRESS,
+                _SAFE_FORK_CHAIN_ID,
+                message,
+            )
+
+    def test_sign_safe_message_accepts_exactly_32_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        """The 32-byte boundary is inclusive; the reference digest signs.
+
+        Companion to the non-32-byte rejection test: proves the guard is
+        an equality check on the boundary rather than a stricter bound
+        that would break the real request-id digest path.
+        """
+        signer = self._signer_for_key(_SAFE_FORK_OWNER_KEY, tmp_path)
+
+        signature = signer.sign_safe_message(
+            _SAFE_FORK_SAFE_ADDRESS,
+            _SAFE_FORK_CHAIN_ID,
+            _SAFE_FORK_REQUEST_ID,
+        )
+
+        assert len(signature) == 65

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -24,13 +24,18 @@ from unittest.mock import MagicMock
 DEFAULT_SIGNER_ADDRESS = "0x" + "1" * 40
 DEFAULT_TX_HASH = "0x" + "ff" * 32
 DEFAULT_SIGNATURE = b"\xab" * 65
+# Agent-mode signing rejects any v byte outside {27, 28} so the raw ECDSA
+# path stays distinguishable from Safe's contract-signature and
+# approved-hash markers. Default to v=27 so tests that don't care about
+# the v byte still produce a shape the guard accepts.
+DEFAULT_SAFE_SIGNATURE = b"\xab" * 64 + b"\x1b"
 
 
 def create_mock_signer(
     address: str = DEFAULT_SIGNER_ADDRESS,
     tx_hash: str = DEFAULT_TX_HASH,
     signature: bytes = DEFAULT_SIGNATURE,
-    safe_signature: bytes = DEFAULT_SIGNATURE,
+    safe_signature: bytes = DEFAULT_SAFE_SIGNATURE,
 ) -> MagicMock:
     """
     Create a mock Signer.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -30,17 +30,20 @@ def create_mock_signer(
     address: str = DEFAULT_SIGNER_ADDRESS,
     tx_hash: str = DEFAULT_TX_HASH,
     signature: bytes = DEFAULT_SIGNATURE,
+    safe_signature: bytes = DEFAULT_SIGNATURE,
 ) -> MagicMock:
     """
     Create a mock Signer.
 
     :param address: EOA address the signer reports
     :param tx_hash: Transaction hash send_transaction returns
-    :param signature: Signature bytes sign_message returns
+    :param signature: Signature bytes sign_message returns (client mode)
+    :param safe_signature: Signature bytes sign_safe_message returns (agent mode)
     :return: Mock signer instance
     """
     mock_signer = MagicMock()
     mock_signer.address = address
     mock_signer.send_transaction.return_value = tx_hash
     mock_signer.sign_message.return_value = signature
+    mock_signer.sign_safe_message.return_value = safe_signature
     return mock_signer

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -34,6 +34,7 @@ from mech_client.services.marketplace_service import (
     MarketplaceService,
     PaymentChallenge,
 )
+from mech_client.utils.validators import ensure_checksummed_address
 
 from tests.unit.helpers import create_mock_signer
 
@@ -1505,6 +1506,199 @@ class TestSendOffchainRequest:
     @patch("mech_client.services.marketplace_service.EthereumCrypto")
     @patch("mech_client.services.base_service.EthereumApi")
     @patch("mech_client.services.base_service.get_mech_config")
+    async def test_client_mode_offchain_uses_eoa_as_requester(
+        self,
+        mock_config: MagicMock,
+        mock_ledger_api_cls: MagicMock,
+        mock_crypto: MagicMock,
+        mock_executor_factory: MagicMock,
+        mock_tool_manager: MagicMock,
+        mock_ipfs_client: MagicMock,
+        mock_offchain_watcher_cls: MagicMock,
+    ) -> None:
+        """Client-mode offchain request binds the EOA as the requester.
+
+        Symmetric to the agent-mode invariant: with no Safe, the EOA is
+        ``msg.sender`` on the settlement path and must be the address the
+        offchain payload, ``mapNonces`` lookup, and ``getRequestId`` all
+        key on. The Safe-wrapped signing helper must not be exercised.
+        """
+        mock_mech_config = create_mock_mech_config()
+        mock_mech_config.priority_mech_address = "0x" + "9" * 40
+        mock_config.return_value = mock_mech_config
+        mock_executor_factory.create.return_value = MagicMock()
+        mock_ledger_api_cls.return_value = MagicMock()
+
+        service = MarketplaceService(
+            chain_config="gnosis",
+            agent_mode=False,
+            crypto=create_mock_crypto(),
+        )
+        service.signer = _real_signing_signer()
+
+        mock_contract = MagicMock()
+        mock_contract.functions.mapNonces.return_value.call.return_value = 3
+        request_id_bytes = b"\xcd" * 32
+        mock_contract.functions.getRequestId.return_value.call.return_value = (
+            request_id_bytes
+        )
+
+        mock_watcher = AsyncMock()
+        mock_watcher.watch.return_value = {request_id_bytes.hex(): "ok"}
+        mock_offchain_watcher_cls.return_value = mock_watcher
+
+        with patch(
+            "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
+            return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hi"}'),
+        ):
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
+                mock_response = MagicMock()
+                mock_response.ok = True
+                mock_response.json.return_value = {"status": "ok"}
+                mock_requests.post.return_value = mock_response
+                mock_requests.exceptions.RequestException = Exception
+
+                await service._send_offchain_request(  # pylint: disable=protected-access
+                    marketplace_contract=mock_contract,
+                    prompts=("hi",),
+                    tools=("some-tool",),
+                    priority_mech_address="0x" + "9" * 40,
+                    max_delivery_rate=10**17,
+                    payment_type=PaymentType.NATIVE,
+                    response_timeout=300,
+                    mech_offchain_url="https://mech.example.com",
+                    extra_attributes=None,
+                    timeout=30.0,
+                )
+
+        expected_sender = ensure_checksummed_address(_TEST_ACCOUNT.address)
+
+        # Requester of record on all three surfaces is the EOA
+        mock_contract.functions.mapNonces.assert_called_once_with(expected_sender)
+        assert (
+            mock_contract.functions.getRequestId.call_args.args[1] == expected_sender
+        )
+        posted_payload = mock_requests.post.call_args.kwargs["data"]
+        assert posted_payload["sender"] == expected_sender
+
+        # Safe-wrapped signing path is not exercised in client mode
+        service.signer.sign_safe_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("mech_client.services.marketplace_service.OffchainDeliveryWatcher")
+    @patch("mech_client.services.marketplace_service.IPFSClient")
+    @patch("mech_client.services.marketplace_service.ToolManager")
+    @patch("mech_client.services.base_service.ExecutorFactory")
+    @patch("mech_client.services.marketplace_service.EthereumCrypto")
+    @patch("mech_client.services.base_service.EthereumApi")
+    @patch("mech_client.services.base_service.get_mech_config")
+    async def test_agent_mode_offchain_uses_safe_as_requester(
+        self,
+        mock_config: MagicMock,
+        mock_ledger_api_cls: MagicMock,
+        mock_crypto: MagicMock,
+        mock_executor_factory: MagicMock,
+        mock_tool_manager: MagicMock,
+        mock_ipfs_client: MagicMock,
+        mock_offchain_watcher_cls: MagicMock,
+    ) -> None:
+        """Agent-mode offchain request binds the Safe as the requester.
+
+        End-to-end assertion of the requester-of-record property: the
+        Safe address (not the signer EOA) must be the address passed to
+        ``mapNonces``, into ``getRequestId``, and set as ``sender`` on the
+        payload posted to the mech. The mech, subgraph, and settlement
+        path all key on that field, so any of the three falling back to
+        the EOA would split the identity across the offchain and onchain
+        flows.
+        """
+        mock_mech_config = create_mock_mech_config()
+        mock_mech_config.priority_mech_address = "0x" + "9" * 40
+        mock_config.return_value = mock_mech_config
+        mock_executor_factory.create.return_value = MagicMock()
+        mock_ledger_api_cls.return_value = MagicMock()
+
+        safe = "0x" + "5a" * 20
+        service = MarketplaceService(
+            chain_config="gnosis",
+            agent_mode=True,
+            crypto=create_mock_crypto(),
+            safe_address=safe,
+            ethereum_client=MagicMock(),
+        )
+        # Distinct EOA so a regression that binds the signer would surface
+        service.signer = create_mock_signer(
+            address="0x" + "e0" * 20, safe_signature=b"\xdd" * 65
+        )
+
+        mock_contract = MagicMock()
+        mock_contract.functions.mapNonces.return_value.call.return_value = 7
+        request_id_bytes = b"\xab" * 32
+        mock_contract.functions.getRequestId.return_value.call.return_value = (
+            request_id_bytes
+        )
+
+        mock_watcher = AsyncMock()
+        mock_watcher.watch.return_value = {request_id_bytes.hex(): "ok"}
+        mock_offchain_watcher_cls.return_value = mock_watcher
+
+        with patch(
+            "mech_client.infrastructure.ipfs.metadata.fetch_ipfs_hash",
+            return_value=("0x" + "b" * 64, "full-hash", '{"prompt":"hi"}'),
+        ):
+            with patch(
+                "mech_client.services.marketplace_service.requests"
+            ) as mock_requests:
+                mock_response = MagicMock()
+                mock_response.ok = True
+                mock_response.json.return_value = {"status": "ok"}
+                mock_requests.post.return_value = mock_response
+                mock_requests.exceptions.RequestException = Exception
+
+                await service._send_offchain_request(  # pylint: disable=protected-access
+                    marketplace_contract=mock_contract,
+                    prompts=("hi",),
+                    tools=("some-tool",),
+                    priority_mech_address="0x" + "9" * 40,
+                    max_delivery_rate=10**17,
+                    payment_type=PaymentType.NATIVE,
+                    response_timeout=300,
+                    mech_offchain_url="https://mech.example.com",
+                    extra_attributes=None,
+                    timeout=30.0,
+                )
+
+        expected_sender = ensure_checksummed_address(safe)
+
+        # 1. mapNonces was keyed on the Safe, not the EOA
+        mock_contract.functions.mapNonces.assert_called_once_with(expected_sender)
+
+        # 2. getRequestId was computed against the Safe as requester
+        get_req_call = mock_contract.functions.getRequestId.call_args
+        assert get_req_call.args[1] == expected_sender
+
+        # 3. The signature was produced through the Safe-wrapped path
+        service.signer.sign_safe_message.assert_called_once_with(
+            expected_sender,
+            service.mech_config.ledger_config.chain_id,
+            request_id_bytes,
+        )
+
+        # 4. The payload posted to the mech advertised the Safe as sender
+        posted_payload = mock_requests.post.call_args.kwargs["data"]
+        assert posted_payload["sender"] == expected_sender
+        assert posted_payload["signature"] == "0x" + ("dd" * 65)
+
+    @pytest.mark.asyncio
+    @patch("mech_client.services.marketplace_service.OffchainDeliveryWatcher")
+    @patch("mech_client.services.marketplace_service.IPFSClient")
+    @patch("mech_client.services.marketplace_service.ToolManager")
+    @patch("mech_client.services.base_service.ExecutorFactory")
+    @patch("mech_client.services.marketplace_service.EthereumCrypto")
+    @patch("mech_client.services.base_service.EthereumApi")
+    @patch("mech_client.services.base_service.get_mech_config")
     async def test_offchain_request_http_error_raises(
         self,
         mock_config: MagicMock,
@@ -1777,6 +1971,75 @@ class TestSignRequestDigest:
         with pytest.raises(ValueError, match="cannot be recovered"):
             service._sign_request_digest(self._digest())
 
+    def test_agent_mode_signs_via_safe_message_wrapper(self) -> None:
+        """Agent-mode signing routes through sign_safe_message with the Safe."""
+        safe = "0x" + "5a" * 20
+        service = _build_offchain_service_agent_mode(safe_address=safe)
+        service.signer = create_mock_signer(safe_signature=b"\xdd" * 65)
+
+        signature = service._sign_request_digest(self._digest())
+
+        assert signature == "0x" + ("dd" * 65)
+        service.signer.sign_safe_message.assert_called_once_with(
+            ensure_checksummed_address(safe),
+            service.mech_config.ledger_config.chain_id,
+            self._digest(),
+        )
+        # Client-mode signing path must not be exercised in agent mode
+        service.signer.sign_message.assert_not_called()
+
+    def test_agent_mode_rejects_wrong_length_safe_signature(self) -> None:
+        """Agent-mode signing fails fast on a non-65-byte SafeMessage signature."""
+        service = _build_offchain_service_agent_mode()
+        service.signer = create_mock_signer(safe_signature=b"\xdd" * 64)
+
+        with pytest.raises(ValueError, match="expected\\s+65 bytes"):
+            service._sign_request_digest(self._digest())
+
+
+class TestOffchainSenderResolution:
+    """Tests for the requester address bound into offchain requests."""
+
+    def test_client_mode_binds_signer_address(self) -> None:
+        """Client mode uses the EOA as the offchain requester."""
+        service = _build_offchain_service()
+        service.signer = create_mock_signer(address="0x" + "1" * 40)
+
+        # pylint: disable-next=protected-access
+        sender = service._resolve_offchain_sender()
+
+        assert sender == ensure_checksummed_address("0x" + "1" * 40)
+
+    def test_agent_mode_binds_safe_address(self) -> None:
+        """Agent mode uses the Safe as the offchain requester of record.
+
+        This is the invariant that keeps the offchain flow consistent with
+        the onchain flow — where the Safe is ``msg.sender`` and therefore
+        the requester recorded by the marketplace and indexed by the
+        subgraph. Binding the signer EOA in agent mode would split the two
+        views of "who owns this request".
+        """
+        safe = "0x" + "5a" * 20
+        service = _build_offchain_service_agent_mode(safe_address=safe)
+        service.signer = create_mock_signer(address="0x" + "1" * 40)
+
+        # pylint: disable-next=protected-access
+        sender = service._resolve_offchain_sender()
+
+        assert sender == ensure_checksummed_address(safe)
+        # Assert the EOA is NOT bound — that would be the client-mode value
+        # and would fail Safe.isValidSignature downstream.
+        assert sender != ensure_checksummed_address("0x" + "1" * 40)
+
+    def test_agent_mode_without_safe_address_raises(self) -> None:
+        """Agent mode without a Safe address surfaces a clear configuration error."""
+        service = _build_offchain_service_agent_mode()
+        service.safe_address = None
+
+        with pytest.raises(ValueError, match="require a Safe address"):
+            # pylint: disable-next=protected-access
+            service._resolve_offchain_sender()
+
 
 class TestSendRequestOffchainBranch:
     """Test send_request routing to _send_offchain_request (lines 141-154)."""
@@ -1866,6 +2129,34 @@ def _build_offchain_service() -> MarketplaceService:
             chain_config="gnosis",
             agent_mode=False,
             crypto=create_mock_crypto(),
+        )
+
+
+def _build_offchain_service_agent_mode(
+    safe_address: str = "0x" + "5a" * 20,
+) -> MarketplaceService:
+    """Build an agent-mode MarketplaceService with heavy init dependencies mocked.
+
+    :param safe_address: Safe address to bind as the requester of record
+    :return: Agent-mode marketplace service instance
+    """
+    with (
+        patch(
+            "mech_client.services.base_service.get_mech_config",
+            return_value=create_mock_mech_config(),
+        ),
+        patch("mech_client.services.base_service.EthereumApi"),
+        patch("mech_client.services.base_service.ExecutorFactory"),
+        patch("mech_client.services.marketplace_service.EthereumCrypto"),
+        patch("mech_client.services.marketplace_service.ToolManager"),
+        patch("mech_client.services.marketplace_service.IPFSClient"),
+    ):
+        return MarketplaceService(
+            chain_config="gnosis",
+            agent_mode=True,
+            crypto=create_mock_crypto(),
+            safe_address=safe_address,
+            ethereum_client=MagicMock(),
         )
 
 

--- a/tests/unit/services/test_marketplace_service.py
+++ b/tests/unit/services/test_marketplace_service.py
@@ -1630,7 +1630,7 @@ class TestSendOffchainRequest:
         )
         # Distinct EOA so a regression that binds the signer would surface
         service.signer = create_mock_signer(
-            address="0x" + "e0" * 20, safe_signature=b"\xdd" * 65
+            address="0x" + "e0" * 20, safe_signature=b"\xdd" * 64 + b"\x1b"
         )
 
         mock_contract = MagicMock()
@@ -1689,7 +1689,7 @@ class TestSendOffchainRequest:
         # 4. The payload posted to the mech advertised the Safe as sender
         posted_payload = mock_requests.post.call_args.kwargs["data"]
         assert posted_payload["sender"] == expected_sender
-        assert posted_payload["signature"] == "0x" + ("dd" * 65)
+        assert posted_payload["signature"] == "0x" + ("dd" * 64) + "1b"
 
     @pytest.mark.asyncio
     @patch("mech_client.services.marketplace_service.OffchainDeliveryWatcher")
@@ -1923,7 +1923,9 @@ class TestSignRequestDigest:
         service = _build_offchain_service()
         service.signer = _real_signing_signer()
 
-        signature = service._sign_request_digest(self._digest())
+        signature = service._sign_request_digest(
+            _TEST_ACCOUNT.address, self._digest()
+        )
 
         expected = bytes(_TEST_ACCOUNT.unsafe_sign_hash(self._digest()).signature)
         assert signature == "0x" + expected.hex()
@@ -1937,7 +1939,9 @@ class TestSignRequestDigest:
             address=_TEST_ACCOUNT.address, signature=low_v
         )
 
-        signature = service._sign_request_digest(self._digest())
+        signature = service._sign_request_digest(
+            _TEST_ACCOUNT.address, self._digest()
+        )
 
         # The low-v original goes out; normalization is check-only
         assert signature == "0x" + low_v.hex()
@@ -1953,7 +1957,7 @@ class TestSignRequestDigest:
         )
 
         with pytest.raises(ValueError, match="EIP-191"):
-            service._sign_request_digest(self._digest())
+            service._sign_request_digest(_TEST_ACCOUNT.address, self._digest())
 
     def test_wrong_length_signature_is_rejected(self) -> None:
         """A non-65-byte signature fails fast with a clear message."""
@@ -1961,7 +1965,9 @@ class TestSignRequestDigest:
         service.signer = create_mock_signer(signature=b"\xab" * 64)
 
         with pytest.raises(ValueError, match="expected\\s+65 bytes"):
-            service._sign_request_digest(self._digest())
+            service._sign_request_digest(
+                create_mock_signer().address, self._digest()
+            )
 
     def test_unrecoverable_signature_is_rejected(self) -> None:
         """A malformed signature (r = s = 0) surfaces a diagnostic error."""
@@ -1969,32 +1975,103 @@ class TestSignRequestDigest:
         service.signer = create_mock_signer(signature=b"\x00" * 64 + b"\x1b")
 
         with pytest.raises(ValueError, match="cannot be recovered"):
-            service._sign_request_digest(self._digest())
+            service._sign_request_digest(
+                create_mock_signer().address, self._digest()
+            )
 
     def test_agent_mode_signs_via_safe_message_wrapper(self) -> None:
         """Agent-mode signing routes through sign_safe_message with the Safe."""
         safe = "0x" + "5a" * 20
-        service = _build_offchain_service_agent_mode(safe_address=safe)
-        service.signer = create_mock_signer(safe_signature=b"\xdd" * 65)
+        service = _build_offchain_service(agent_mode=True, safe_address=safe)
+        service.signer = create_mock_signer(safe_signature=b"\xdd" * 64 + b"\x1b")
+        checksummed_safe = ensure_checksummed_address(safe)
 
-        signature = service._sign_request_digest(self._digest())
+        signature = service._sign_request_digest(checksummed_safe, self._digest())
 
-        assert signature == "0x" + ("dd" * 65)
+        assert signature == "0x" + ("dd" * 64) + "1b"
         service.signer.sign_safe_message.assert_called_once_with(
-            ensure_checksummed_address(safe),
+            checksummed_safe,
             service.mech_config.ledger_config.chain_id,
             self._digest(),
         )
         # Client-mode signing path must not be exercised in agent mode
         service.signer.sign_message.assert_not_called()
 
+    def test_agent_mode_signs_against_caller_provided_sender(self) -> None:
+        """The signature is bound to the sender argument, not re-resolved.
+
+        Threading ``sender`` through the API is the invariant that keeps
+        the signed-over address identical to the address written into
+        the payload and ``getRequestId``. Passing a distinct Safe address
+        as ``sender`` (with the service configured for a different Safe)
+        proves the sign path uses the caller's value rather than
+        re-reading ``self.safe_address``.
+        """
+        service = _build_offchain_service(agent_mode=True)
+        service.signer = create_mock_signer(safe_signature=b"\xdd" * 64 + b"\x1b")
+        other_safe = ensure_checksummed_address("0x" + "cc" * 20)
+
+        service._sign_request_digest(other_safe, self._digest())
+
+        service.signer.sign_safe_message.assert_called_once_with(
+            other_safe,
+            service.mech_config.ledger_config.chain_id,
+            self._digest(),
+        )
+
     def test_agent_mode_rejects_wrong_length_safe_signature(self) -> None:
         """Agent-mode signing fails fast on a non-65-byte SafeMessage signature."""
-        service = _build_offchain_service_agent_mode()
+        service = _build_offchain_service(agent_mode=True)
         service.signer = create_mock_signer(safe_signature=b"\xdd" * 64)
 
         with pytest.raises(ValueError, match="expected\\s+65 bytes"):
-            service._sign_request_digest(self._digest())
+            service._sign_request_digest(
+                ensure_checksummed_address("0x" + "5a" * 20), self._digest()
+            )
+
+    @pytest.mark.parametrize("bad_v", [0, 1, 26, 29, 255])
+    def test_agent_mode_rejects_unsupported_v_byte(self, bad_v: int) -> None:
+        """Agent-mode signing requires v in {27, 28}.
+
+        Safe reads ``v=0`` as a contract signature marker and ``v=1`` as
+        an approved-hash marker, both distinct from raw ECDSA recovery.
+        A signer that returns any other ``v`` would be misinterpreted
+        on-chain and fail as an opaque ``GS026``; the guard converts
+        that into an actionable local error.
+        """
+        service = _build_offchain_service(agent_mode=True)
+        bad_sig = b"\xdd" * 64 + bytes([bad_v])
+        service.signer = create_mock_signer(safe_signature=bad_sig)
+
+        with pytest.raises(ValueError, match=r"v in \{27, 28\}"):
+            service._sign_request_digest(
+                ensure_checksummed_address("0x" + "5a" * 20), self._digest()
+            )
+
+    def test_agent_mode_requires_signer_with_sign_safe_message(self) -> None:
+        """A signer missing sign_safe_message surfaces an actionable error.
+
+        Downstream :class:`Signer` implementations predating this method
+        (e.g. Pearl BYOA signers) would otherwise die with a bare
+        ``AttributeError`` deep in the request flow; catching the missing
+        attribute early names the requirement and points to the protocol.
+        """
+        service = _build_offchain_service(agent_mode=True)
+        # A plain object without sign_safe_message. Using ``spec`` on a
+        # MagicMock would also work, but this keeps the point explicit.
+
+        class _LegacySigner:
+            address = "0x" + "1" * 40
+
+            def sign_message(self, message: bytes) -> bytes:
+                return b"\x00" * 65
+
+        service.signer = _LegacySigner()  # type: ignore[assignment]
+
+        with pytest.raises(ValueError, match="sign_safe_message"):
+            service._sign_request_digest(
+                ensure_checksummed_address("0x" + "5a" * 20), self._digest()
+            )
 
 
 class TestOffchainSenderResolution:
@@ -2020,7 +2097,7 @@ class TestOffchainSenderResolution:
         views of "who owns this request".
         """
         safe = "0x" + "5a" * 20
-        service = _build_offchain_service_agent_mode(safe_address=safe)
+        service = _build_offchain_service(agent_mode=True, safe_address=safe)
         service.signer = create_mock_signer(address="0x" + "1" * 40)
 
         # pylint: disable-next=protected-access
@@ -2033,7 +2110,7 @@ class TestOffchainSenderResolution:
 
     def test_agent_mode_without_safe_address_raises(self) -> None:
         """Agent mode without a Safe address surfaces a clear configuration error."""
-        service = _build_offchain_service_agent_mode()
+        service = _build_offchain_service(agent_mode=True)
         service.safe_address = None
 
         with pytest.raises(ValueError, match="require a Safe address"):
@@ -2112,33 +2189,17 @@ class TestSendRequestOffchainBranch:
         assert result["tx_hash"] is None
 
 
-def _build_offchain_service() -> MarketplaceService:
-    """Build a MarketplaceService with its heavy init dependencies mocked."""
-    with (
-        patch(
-            "mech_client.services.base_service.get_mech_config",
-            return_value=create_mock_mech_config(),
-        ),
-        patch("mech_client.services.base_service.EthereumApi"),
-        patch("mech_client.services.base_service.ExecutorFactory"),
-        patch("mech_client.services.marketplace_service.EthereumCrypto"),
-        patch("mech_client.services.marketplace_service.ToolManager"),
-        patch("mech_client.services.marketplace_service.IPFSClient"),
-    ):
-        return MarketplaceService(
-            chain_config="gnosis",
-            agent_mode=False,
-            crypto=create_mock_crypto(),
-        )
-
-
-def _build_offchain_service_agent_mode(
+def _build_offchain_service(
+    agent_mode: bool = False,
     safe_address: str = "0x" + "5a" * 20,
 ) -> MarketplaceService:
-    """Build an agent-mode MarketplaceService with heavy init dependencies mocked.
+    """Build a MarketplaceService with its heavy init dependencies mocked.
 
-    :param safe_address: Safe address to bind as the requester of record
-    :return: Agent-mode marketplace service instance
+    :param agent_mode: True to build an agent-mode (Safe-bound) service,
+        False for the default client-mode (EOA) service
+    :param safe_address: Safe address to bind as requester of record
+        (agent mode only, ignored in client mode)
+    :return: MarketplaceService instance
     """
     with (
         patch(
@@ -2151,13 +2212,15 @@ def _build_offchain_service_agent_mode(
         patch("mech_client.services.marketplace_service.ToolManager"),
         patch("mech_client.services.marketplace_service.IPFSClient"),
     ):
-        return MarketplaceService(
-            chain_config="gnosis",
-            agent_mode=True,
-            crypto=create_mock_crypto(),
-            safe_address=safe_address,
-            ethereum_client=MagicMock(),
-        )
+        kwargs: Dict[str, Any] = {
+            "chain_config": "gnosis",
+            "agent_mode": agent_mode,
+            "crypto": create_mock_crypto(),
+        }
+        if agent_mode:
+            kwargs["safe_address"] = safe_address
+            kwargs["ethereum_client"] = MagicMock()
+        return MarketplaceService(**kwargs)
 
 
 def _mock_http_response(

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 extra_deps =
     py-multibase==1.0.3
     py-multicodec==0.2.1
-    open-autonomy[all]==0.21.25
+    open-autonomy[all]==0.21.26
     grpcio==1.78.0
     protobuf<7,>=5
 
@@ -114,7 +114,7 @@ ignore_missing_imports = True
 [Authorized Packages]
 ; open-autonomy wheel metadata reports "Other/Proprietary" due to the
 ; license-classifier mapping in its build metadata; actual license is Apache-2.0.
-open-autonomy: ==0.21.25
+open-autonomy: ==0.21.26
 ; open-aea-flashbots ships without license classifier metadata; Apache-2.0.
 open-aea-flashbots: *
 blspy: 2.0.2

--- a/uv.lock
+++ b/uv.lock
@@ -1953,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "mech-client"
-version = "0.21.2"
+version = "0.21.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1983,7 +1983,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1,<9" },
     { name = "gql", specifier = ">=3.4.1" },
     { name = "olas-operate-middleware", specifier = ">=0.15.2,<0.16" },
-    { name = "open-aea-helpers", specifier = "==0.21.25" },
+    { name = "open-aea-helpers", specifier = "==0.21.26" },
     { name = "pip", specifier = ">=24.0" },
     { name = "py-multibase", specifier = "==1.0.3" },
     { name = "py-multicodec", specifier = "==0.2.1" },
@@ -2333,14 +2333,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-helpers"
-version = "0.21.25"
+version = "0.21.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "open-autonomy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/66/6f78f598fcd0bf9b826b82b00276e12932117d8b3d48b681bcf25d9ed8fb/open_aea_helpers-0.21.25.tar.gz", hash = "sha256:4e061cb30e95b1c260b7ac4ef7e8a2b3a9cf680e3671db3f57e725cea638f4ee", size = 41119, upload-time = "2026-06-25T11:17:26.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/76/60c31f9757505d84ee14392077eb6f804b0f3150f282a97de58c27f9c3c9/open_aea_helpers-0.21.26.tar.gz", hash = "sha256:c76c328c3147ea6c7318c4968cfa465f987162fd4bc377c43db8f86fd82384dc", size = 41116, upload-time = "2026-07-03T12:36:13.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/db/e3e37e30f9a9043bbbb99d6f8628c0599aab1864e2716a2c864233add00e/open_aea_helpers-0.21.25-py3-none-any.whl", hash = "sha256:7c62788b67d26add7f719c3becd875d697f3420696c035644dd02bda409a57d4", size = 44413, upload-time = "2026-06-25T11:17:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a0/993a7abaab4520706fc54d5bfd16164d54aec45d1ccc3efcf5f3deed6a16/open_aea_helpers-0.21.26-py3-none-any.whl", hash = "sha256:f6039f3f0fad3abbcc6862c7d416373e6c6d98e620174b394eba611389d3152e", size = 44415, upload-time = "2026-07-03T12:36:12.861Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Aligns mech-client's offchain marketplace flow with the onchain flow. In agent mode, the Safe multisig is now the requester of record on every surface that keys on identity:

- Payload `sender` field posted to the mech server
- `mapNonces(sender)` lookup on the marketplace
- `getRequestId(mech, sender, ...)` computation
- On-chain signature verification (`_verifySignedHash` in MechMarketplace)

Client mode is unchanged and continues to bind the EOA.

## Why this change

Before this PR, the offchain flow used `sender = self.signer.address` (the EOA). Two problems:

1. **Internal inconsistency with the onchain flow.** In agent mode, onchain requests already have the Safe as msg.sender, so the marketplace records `requester = Safe`, and deposits (also from the Safe via the executor) credit `mapRequesterBalances[Safe]`. Offchain declared the EOA as sender, so the mech server pre-flighted `mapRequesterBalances[EOA]` which was always 0. Every agent-mode offchain request would hit HTTP 402 forever, because auto-deposit still credits the Safe slot (the executor sends from the Safe).
2. **Inconsistency with the Autonolas service model.** A service is represented by a Safe multisig. Every other component in the ecosystem (the trader via mech-interact, the marketplace, the subgraph's aggregation over on-chain traffic) treats the Safe as the entity that owns a request. Offchain being EOA-based was an outlier.

Live subgraph data confirms the direction. On Gnosis marketplace-gnosis subgraph, all 10 most recent `MarketplaceRequest` events (onchain path) have Safe requesters with threshold 1. The 41 `MarketplaceDeliveryWithSignatures` events that exist across all history (offchain-signed path) all have EOA requesters, and are entirely test volume from mech-client. Aligning mech-client's offchain path to Safe-as-sender fits both the production convention and the ecosystem model.

## What changed

- `Signer.sign_safe_message(safe_address, chain_id, message) -> bytes` added to the signer protocol. Downstream `Signer` implementers (e.g. Pearl BYOA) must add this method to remain compatible with agent-mode offchain requests. Client mode is served by the existing `sign_message` and requires no changes.
- `LocalSigner.sign_safe_message` computes the Safe v1.4.1 SafeMessage EIP-712 wrapped hash locally (no RPC round-trip to `Safe.getMessageHash`) and signs it raw. Documented Safe v1.4.1 assumption (chainId in the EIP-712 domain).
- `MarketplaceService._resolve_offchain_sender()` returns the Safe in agent mode and the EOA in client mode. All identity-keyed surfaces (nonce, request-id, payload sender, signature) bind to the same address per mode.
- `MarketplaceService._sign_request_digest` is mode-conditional: agent mode routes through `sign_safe_message`, client mode keeps the raw-digest path.
- Deposit flow left alone (already credits `msg.sender = Safe` in agent mode, which is now the requester of record).
- Version bumps: mech-client `0.21.2` -> `0.21.3`, `open-autonomy 0.21.25` -> `0.21.26`, `open-aea-helpers 0.21.25` -> `0.21.26`.

## Signature verification, and why two formats

`MechMarketplace._verifySignedHash` branches on the requester's bytecode:

```solidity
if (requester.code.length > 0) {
    // Safe branch: EIP-1271 magic value check
    ISignatureValidator(requester).isValidSignature(request_id, sig) == MAGIC_VALUE
} else {
    // EOA branch: plain ecrecover on the raw digest
    require(ecrecover(request_id, v, r, s) == requester);
}
```

There is no single signature format that both branches accept. Safe's `CompatibilityFallbackHandler` (v1.4.1) wraps the raw `request_id` into a `SafeMessage` EIP-712 struct bound to `(chainId, safeAddress)` and validates against the wrapped hash. A raw-ECDSA signature over the unwrapped digest reverts with `GS026`. So the client signs the raw digest in client mode and the wrapped hash in agent mode. Same signing key, same signing function underneath. Only the 32-byte input differs.

## Test plan

- [x] Unit tests for `LocalSigner.sign_safe_message`: fork-verified reference vector, invariants across Safe/chainId/message inputs.
- [x] Unit tests for `MarketplaceService._resolve_offchain_sender`: agent vs client mode, missing-Safe error.
- [x] Unit tests for `MarketplaceService._sign_request_digest`: agent-mode wrapper, length guard.
- [x] Integration-style tests: end-to-end offchain request binds EOA in client mode and Safe in agent mode (mapNonces, getRequestId, payload sender all consistent).
- [x] Fork verification (Gnosis mainnet via anvil): freshly-deployed Safe v1.4.1 returns `0x1626ba7e` from `isValidSignature` for signatures produced by `LocalSigner.sign_safe_message`.
- [x] Full CI locally: black, isort, flake8, mypy, pylint (10.00/10), darglint, bandit, liccheck, check-third-party-hashes, check-copyright, gitleaks, uv lock check.
- [x] 767 tests pass, 100% coverage maintained.

## Follow-up

`valory-xyz/mech-interact#112` applies the same SafeMessage-wrapped signing to `_sign_request_id` so their existing Safe-as-sender offchain path can settle on-chain.

Fixes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)