### PR TITLE
chore: bump version to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-12
+
 ### ✨ Added
 
 #### NVM Subscription Module Refactoring

--- a/mech_client/__init__.py
+++ b/mech_client/__init__.py
@@ -35,7 +35,7 @@ instead of ``crypto``:
     ... )
 """
 
-__version__ = "0.21.3"
+__version__ = "0.22.0"
 
 # Signing
 from mech_client.domain.signing import LocalSigner, Signer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mech-client"
-version = "0.21.3"
+version = "0.22.0"
 description = "Basic client to interact with a mech"
 requires-python = ">=3.10,<3.15"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1953,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "mech-client"
-version = "0.21.3"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**Stacked on #251** — base is `fix/delivery-results-return-delivered-content`, not `main`. Merge #251 first; this PR's base will then retarget to `main` automatically. Review only the single commit here, since the diff against `main` includes #251's changes.

## Why 0.22.0 and not 0.21.4

#251 replaces `send_request`'s `delivery_results` key with `deliveries`, which breaks anyone reading the old key. Under semver on 0.x, that is a minor bump.

## Release checklist

Per `CLAUDE.md`:

| Step | Result |
|---|---|
| `pyproject.toml`, `mech_client/__init__.py` | `0.21.3` → `0.22.0` |
| `SECURITY.md` | **Does not exist** — checklist is stale |
| `uv lock` | Updated; `uv lock --check` passes |
| `autonomy packages sync --update-packages` | No-op, hashes unchanged |
| `make dist` | Builds `mech_client-0.22.0-py3-none-any.whl` + `.tar.gz` |

The CHANGELOG's `[Unreleased]` section is closed into `## [0.22.0] - 2026-08-12`, leaving an empty `[Unreleased]` for future work.

## Verified

- `mechx --version` reports `0.22.0`; no `0.21.3` references remain
- 791 tests pass, 100% coverage under CI's `--cov-fail-under=100`
- All linters, bandit, and the copyright check pass

## Two things for a follow-up (not addressed here)

1. **The CHANGELOG has a pre-existing gap.** Released headings jump from `[0.17.2]` to `[Unreleased]`, but tags `v0.18.x`–`v0.21.3` exist. Everything accumulated since 0.17.2 now sits under 0.22.0, so that section overstates what is actually new in this release. Untangling four releases of history is out of scope for a version bump.
2. **`CLAUDE.md`'s release and lint instructions are drifting.** `SECURITY.md` does not exist; the documented `tox -e black-check,...` and the `vulture` env do not exist either — the real invocation is `tomte tox -e ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)